### PR TITLE
Add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,9 +47,14 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      # Setup Gradle and Handle Caching for faster builds
       - name: Setup Gradle
         if: matrix.language == 'java-kotlin'
         uses: gradle/actions/setup-gradle@v5
+        with:
+          # This should be the default behavior for pull_request, but we won't task risks. If this is not enabled, a bad actor could write in the cache bad stuff and this could get reused during the build CI when reading cache.
+          # https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only
+          cache-read-only: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
This pull request introduces a new workflow for advanced CodeQL analysis. Adding security and code quality checks for the languages used in Shizuku. It alerts when a pull request causes the build process to fail or when CodeQL (GitHub tool) detects code that may introduce an issue.

The workflow is triggered on pull requests from contributors, on a weekly schedule, and can also be manually triggered.

It verifies all of our workflow configurations, as well as C++ files and Java/Kotlin build.

Matrix allows running multiple jobs simultaneously, as we don't need to depend on specific jobs to end before doing the next test.

As for security risks, `pull_request` event does not allow acces to repository tokens, so it's fine.
**See**:
- https://github.com/orgs/community/discussions/180109#discussioncomment-15039590
- https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/
- https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

EDIT:
Would also recommend changing under **Actions>General** `Approval for running fork pull request workflows from contributors` to `Require approval for all external contributors` if you do not want workflow from contributors to run without your approval (like mine just did, totally forgot Github did that 😆) And since whe're at it might as well go with least-privilege configuration and change `Workflow permissions` default to `Read repository contents and packages permissions`. In the build workflow and this one, we manually restrict the permissions anyways.