### PR TITLE
Fix getprop path in rish

### DIFF
--- a/manager/src/main/assets/rish
+++ b/manager/src/main/assets/rish
@@ -7,7 +7,7 @@ if [ ! -f "$DEX" ]; then
   exit 1
 fi
 
-if [ $(getprop ro.build.version.sdk) -ge 34 ]; then
+if [ $(/system/bin/getprop ro.build.version.sdk) -ge 34 ]; then
   if [ -w $DEX ]; then
     echo "On Android 14+, app_process cannot load writable dex."
     echo "Attempting to remove the write permission..."


### PR DESCRIPTION
### Problem
On Termux, running `rish` fails with errors like:

```
/bin/getprop: 1: Syntax error: word unexpected (expecting ")")
/data/data/com.termux/files/home/shizuku/rish[21]: [: 34: unexpected operator/operand
Aborted
```

### Cause
`getprop` is interpreted as `/bin/getprop`, which does not exist.

### Solution
Update the getprop call to use `/system/bin/getprop`.