### PR TITLE
add api to get binder with shell/root privilege via ShizukuService

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "api"]
 	path = api
-	url = https://github.com/thedjchi/Shizuku-API
+	url = https://github.com/sbmatch/Shizuku-API
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "api"]
 	path = api
-	url = https://github.com/sbmatch/Shizuku-API
+	url = https://github.com/thedjchi/Shizuku-API
 	branch = master

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -44,6 +44,7 @@ import kotlin.collections.ArraysKt;
 import moe.shizuku.api.BinderContainer;
 import moe.shizuku.common.util.BuildUtils;
 import moe.shizuku.common.util.OsUtils;
+import moe.shizuku.server.IRemoteCallback;
 import moe.shizuku.server.IShizukuApplication;
 import rikka.hidden.compat.ActivityManagerApis;
 import rikka.hidden.compat.DeviceIdleControllerApis;
@@ -417,6 +418,13 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
     @Override
     public IBinder getSystemService(String name) throws RemoteException {
         return ServiceManager.getService(name);
+    }
+
+    @Override
+    public void test(String text, IRemoteCallback callback) throws RemoteException {
+        Bundle bundle = new Bundle();
+        bundle.putString("test.key", text);
+        callback.sendResult(bundle);
     }
 
     private void onPermissionRevoked(String packageName) {

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -44,7 +44,6 @@ import kotlin.collections.ArraysKt;
 import moe.shizuku.api.BinderContainer;
 import moe.shizuku.common.util.BuildUtils;
 import moe.shizuku.common.util.OsUtils;
-import moe.shizuku.server.IRemoteCallback;
 import moe.shizuku.server.IShizukuApplication;
 import rikka.hidden.compat.ActivityManagerApis;
 import rikka.hidden.compat.DeviceIdleControllerApis;

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -420,13 +420,6 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
         return ServiceManager.getService(name);
     }
 
-    @Override
-    public void test(String text, IRemoteCallback callback) throws RemoteException {
-        Bundle bundle = new Bundle();
-        bundle.putString("test.key", text);
-        callback.sendResult(bundle);
-    }
-
     private void onPermissionRevoked(String packageName) {
         // TODO add runtime permission listener
         getUserServiceManager().removeUserServicesForPackage(packageName);

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -414,6 +414,11 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
         configManager.update(uid, null, mask, value);
     }
 
+    @Override
+    public IBinder getSystemService(String name) throws RemoteException {
+        return ServiceManager.getService(name);
+    }
+
     private void onPermissionRevoked(String packageName) {
         // TODO add runtime permission listener
         getUserServiceManager().removeUserServicesForPackage(packageName);


### PR DESCRIPTION
### 仅需修改以下三处即可

> aidl/src/main/aidl/moe/shizuku/server/IShizukuService.aidl
```
IBinder getSystemService(in String name) = 107;
```
>   server/src/main/java/rikka/shizuku/server/ShizukuService.java
```
  @Override
    public IBinder getSystemService(String name) throws RemoteException {
        return ServiceManager.getService(name);
    }
```

>  api/api/src/main/java/rikka/shizuku/SystemServiceHelper.java
```
    public static IBinder getSystemService(@NonNull String name, boolean withPrivilege) {
        IBinder binder = SYSTEM_SERVICE_CACHE.get(name+"_#"+withPrivilege);
        if (binder == null) {
            try {
                binder = withPrivilege ? Shizuku.requireService().getSystemService(name): (IBinder) getService.invoke(null, name);
            }catch (Throwable e) {
                Log.e("SystemServiceHelper", Log.getStackTraceString(e));
                return null;
            }
            SYSTEM_SERVICE_CACHE.put(name+"_#"+withPrivilege, binder);
        }
        return binder;
    }

    public static IBinder getSystemService(@NonNull String name){
        return getSystemService(name, false);
    }
```