### PR TITLE
Android17 support

### DIFF
--- a/build.gradle.compileSdk36
+++ b/build.gradle.compileSdk36
@@ -11,12 +11,12 @@ idea.module {
 subprojects { subproject ->
     plugins.withId("com.android.base") {
         android {
-            compileSdk = 37
-            buildToolsVersion = "37.0.0"
+            compileSdk = 36
+            buildToolsVersion = "36.0.0"
             ndkVersion = "29.0.13113456"
             defaultConfig {
                 minSdk = 24
-                targetSdk = 37
+                targetSdk = 36
             }
             compileOptions {
                 sourceCompatibility = JavaVersion.VERSION_21
@@ -31,5 +31,5 @@ def baseVersionName = "13.6.0"
 def isBeta = project.hasProperty("beta")
 ext {
     versionCode = gitCommitCount
-    versionName = "${baseVersionName}.r${gitCommitCount}-thedjchi${if (isBeta) "-beta" else ""}" 
+    versionName = "${baseVersionName}.r${gitCommitCount}-thedjchi${if (isBeta) "-beta" else ""}"
 }

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -10,6 +10,11 @@
          privileged server to reach loopback. -->
     <uses-permission android:name="android.permission.USE_LOOPBACK_INTERFACE" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+    <!-- Android 16 gates local-network discovery behind NEARBY_WIFI_DEVICES. -->
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="33" />
     <!-- Needed to receive mDNS multicast for wireless ADB service discovery. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
          privileged server to reach loopback. -->
     <uses-permission android:name="android.permission.USE_LOOPBACK_INTERFACE" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+    <!-- Needed to receive mDNS multicast for wireless ADB service discovery. -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Android 17 (SDK 37): local network access is gated behind these permissions;
+         required for mDNS discovery used by wireless ADB pairing and for the
+         privileged server to reach loopback. -->
+    <uses-permission android:name="android.permission.USE_LOOPBACK_INTERFACE" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbMdns.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbMdns.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.Observer
@@ -17,7 +15,7 @@ import java.net.ServerSocket
 @RequiresApi(Build.VERSION_CODES.R)
 class AdbMdns(
     context: Context, private val serviceType: String,
-    private val observer: Observer<Int>
+    private val observer: Observer<Pair<String, Int>>
 ) {
 
     private var registered = false
@@ -25,9 +23,6 @@ class AdbMdns(
     private var serviceName: String? = null
     private val listener = DiscoveryListener(this)
     private val nsdManager: NsdManager = context.getSystemService(NsdManager::class.java)
-    private val handler = Handler(Looper.getMainLooper())
-    private var restartScheduled = false
-    private var attempts = 0
 
     fun start() {
         if (running) return
@@ -40,7 +35,6 @@ class AdbMdns(
     fun stop() {
         if (!running) return
         running = false
-        handler.removeCallbacksAndMessages(null)
         if (registered) {
             nsdManager.stopServiceDiscovery(listener)
         }
@@ -59,38 +53,28 @@ class AdbMdns(
     }
 
     private fun onServiceLost(info: NsdServiceInfo) {
-        if (info.serviceName == serviceName) observer.onChanged(-1)
+        if (info.serviceName == serviceName) observer.onChanged("" to -1)
     }
 
     private fun onServiceResolved(resolvedService: NsdServiceInfo) {
+        val host = resolvedService.host?.hostAddress ?: return
         if (running && NetworkInterface.getNetworkInterfaces()
                 .asSequence()
                 .any { networkInterface ->
                     networkInterface.inetAddresses
                         .asSequence()
-                        .any { resolvedService.host.hostAddress == it.hostAddress }
+                        .any { host == it.hostAddress }
                 }
-            && isPortAvailable(resolvedService.port)
+            && isPortAvailable(host, resolvedService.port)
         ) {
             serviceName = resolvedService.serviceName
-            observer.onChanged(resolvedService.port)
-        } else if (running && attempts < 5 && !restartScheduled) {
-            attempts++
-            restartScheduled = true
-            val delay = attempts * 1000L
-            handler.postDelayed({
-                if (registered) nsdManager.stopServiceDiscovery(listener)
-                handler.postDelayed({
-                    if (!registered) nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, listener)
-                    restartScheduled = false
-                }, 100L)
-            }, delay)
+            observer.onChanged(host to resolvedService.port)
         }
     }
 
-    private fun isPortAvailable(port: Int) = try {
+    private fun isPortAvailable(host: String, port: Int) = try {
         ServerSocket().use {
-            it.bind(InetSocketAddress("127.0.0.1", port), 1)
+            it.bind(InetSocketAddress(host, port), 1)
             false
         }
     } catch (e: IOException) {

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
@@ -40,6 +40,7 @@ class AdbPairingService : Service() {
         private const val replyAction = "reply"
         private const val remoteInputResultKey = "paring_code"
         private const val portKey = "paring_code"
+        private const val hostKey = "pairing_host"
 
         fun startIntent(context: Context): Intent {
             return Intent(context, AdbPairingService::class.java).setAction(startAction)
@@ -49,20 +50,21 @@ class AdbPairingService : Service() {
             return Intent(context, AdbPairingService::class.java).setAction(stopAction)
         }
 
-        private fun replyIntent(context: Context, port: Int): Intent {
-            return Intent(context, AdbPairingService::class.java).setAction(replyAction).putExtra(portKey, port)
+        private fun replyIntent(context: Context, host: String, port: Int): Intent {
+            return Intent(context, AdbPairingService::class.java).setAction(replyAction)
+                .putExtra(hostKey, host).putExtra(portKey, port)
         }
     }
 
     private var adbMdns: AdbMdns? = null
 
-    private val observer = Observer<Int> { port ->
-        Log.i(tag, "Pairing service port: $port")
+    private val observer = Observer<Pair<String, Int>> { (host, port) ->
+        Log.i(tag, "Pairing service host: $host, port: $port")
         if (port <= 0) return@Observer
 
         // Since the service could be killed before user finishing input,
-        // we need to put the port into Intent
-        val notification = createInputNotification(port)
+        // we need to put the host and port into Intent
+        val notification = createInputNotification(host, port)
 
         getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification)
     }
@@ -91,9 +93,10 @@ class AdbPairingService : Service() {
             }
             replyAction -> {
                 val code = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(remoteInputResultKey) ?: ""
+                val host = intent.getStringExtra(hostKey) ?: "127.0.0.1"
                 val port = intent.getIntExtra(portKey, -1)
                 if (port != -1) {
-                    onInput(code.toString(), port)
+                    onInput(code.toString(), host, port)
                 } else {
                     onStart()
                 }
@@ -151,10 +154,8 @@ class AdbPairingService : Service() {
         return searchingNotification
     }
 
-    private fun onInput(code: String, port: Int): Notification {
+    private fun onInput(code: String, host: String, port: Int): Notification {
         GlobalScope.launch(Dispatchers.IO) {
-            val host = "127.0.0.1"
-
             val key = try {
                 AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
             } catch (e: Throwable) {
@@ -312,7 +313,7 @@ class AdbPairingService : Service() {
         val pendingIntent = PendingIntent.getForegroundService(
             this,
             replyRequestId,
-            replyIntent(this, -1),
+            replyIntent(this, "127.0.0.1", -1),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                 PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             else
@@ -328,14 +329,14 @@ class AdbPairingService : Service() {
             .build()
     }
 
-    private fun replyNotificationAction(port: Int): Notification.Action {
+    private fun replyNotificationAction(host: String, port: Int): Notification.Action {
         // Ensure pending intent is created
         val action = replyNotificationAction
 
         PendingIntent.getForegroundService(
             this,
             replyRequestId,
-            replyIntent(this, port),
+            replyIntent(this, host, port),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                 PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             else
@@ -354,12 +355,12 @@ class AdbPairingService : Service() {
             .build()
     }
 
-    private fun createInputNotification(port: Int): Notification {
+    private fun createInputNotification(host: String, port: Int): Notification {
         return Notification.Builder(this, NOTIFICATION_CHANNEL)
             .setColor(getColor(R.color.notification))
             .setContentTitle(getString(R.string.notification_adb_pairing_service_found_title))
             .setSmallIcon(R.drawable.ic_system_icon)
-            .addAction(replyNotificationAction(port))
+            .addAction(replyNotificationAction(host, port))
             .build()
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
@@ -1,15 +1,18 @@
 package moe.shizuku.manager.adb
 
+import android.Manifest
 import android.app.AppOpsManager
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.NotificationManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -92,7 +95,32 @@ class AdbPairingTutorialActivity : AppBarActivity() {
         }
     }
 
+    // Android 17 (SDK 37) gates local-network access behind ACCESS_LOCAL_NETWORK;
+    // Android 16 (SDK 36) uses NEARBY_WIFI_DEVICES. Without a runtime grant the OS
+    // intercepts the pairing connection with an endless "choose a device" picker.
+    private fun localNetworkPermission(): String? = when {
+        Build.VERSION.SDK_INT >= 37 -> "android.permission.ACCESS_LOCAL_NETWORK"
+        Build.VERSION.SDK_INT >= 36 -> Manifest.permission.NEARBY_WIFI_DEVICES
+        else -> null
+    }
+
+    private val localNetworkPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+            // Start pairing whether or not the grant succeeded; a denial simply means
+            // discovery/connect will fail and the service surfaces the error.
+            doStartPairingService()
+        }
+
     private fun startPairingService() {
+        val permission = localNetworkPermission()
+        if (permission != null && checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {
+            localNetworkPermissionLauncher.launch(permission)
+        } else {
+            doStartPairingService()
+        }
+    }
+
+    private fun doStartPairingService() {
         val intent = AdbPairingService.startIntent(this)
         try {
             startForegroundService(intent)

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -33,7 +33,7 @@ class AdbDialogFragment : DialogFragment() {
         val context = requireContext()
         binding = AdbDialogBinding.inflate(layoutInflater)
         adbMdns = AdbMdns(context, AdbMdns.TLS_CONNECT) {
-            port.postValue(it)
+            port.postValue(it.second)
         }
 
         val builder = MaterialAlertDialogBuilder(context).apply {

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbPairDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbPairDialogFragment.kt
@@ -164,8 +164,12 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
     private val _port = MutableLiveData<Int>()
     val port = _port as LiveData<Int>
 
+    @Volatile
+    private var resolvedHost: String = "127.0.0.1"
+
     private val adbMdns: AdbMdns = AdbMdns(appContext, AdbMdns.TLS_PAIRING) {
-        _port.postValue(it)
+        if (it.second > 0) resolvedHost = it.first
+        _port.postValue(it.second)
     }
 
     init {
@@ -174,7 +178,7 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
 
     fun run(port: Int, password: String) {
         GlobalScope.launch(Dispatchers.IO) {
-            val host = "127.0.0.1"
+            val host = resolvedHost
 
             val key = try {
                 AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")

--- a/manager/src/main/java/moe/shizuku/manager/utils/ShizukuSystemApis.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/ShizukuSystemApis.kt
@@ -2,13 +2,12 @@ package moe.shizuku.manager.utils
 
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import android.content.pm.ParceledListSlice
 import android.os.RemoteException
-import rikka.hidden.compat.PackageManagerApis
 import rikka.hidden.compat.PermissionManagerApis
 import rikka.hidden.compat.UserManagerApis
 import rikka.hidden.compat.util.SystemServiceBinder
 import rikka.shizuku.ShizukuBinderWrapper
+import rikka.shizuku.server.util.InstalledPackagesCompat
 
 object ShizukuSystemApis {
 
@@ -56,15 +55,10 @@ object ShizukuSystemApis {
         return if (!ShizukuStateMachine.isRunning()) {
             ArrayList()
         } else try {
-            val listSlice: ParceledListSlice<PackageInfo>? =
-                PackageManagerApis.getInstalledPackages(
-                    flags,
-                    userId
-                )
-            return if (listSlice != null) {
-                listSlice.list
-            } else ArrayList()
+            InstalledPackagesCompat.getInstalledPackages(flags, userId)
         } catch (tr: RemoteException) {
+            throw RuntimeException(tr.message, tr)
+        } catch (tr: ReflectiveOperationException) {
             throw RuntimeException(tr.message, tr)
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -60,7 +60,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             val port = tcpPort.takeIf { !EnvironmentUtils.isWifiRequired() } ?: callbackFlow {
                 val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->
-                    if (p > 0) trySend(p)
+                    if (p.second > 0) trySend(p.second)
                 }
 
                 var awaitingAuth = false

--- a/server/src/main/java/rikka/shizuku/server/BinderSender.java
+++ b/server/src/main/java/rikka/shizuku/server/BinderSender.java
@@ -20,7 +20,7 @@ import java.util.List;
 import kotlin.collections.ArraysKt;
 import rikka.hidden.compat.ActivityManagerApis;
 import rikka.hidden.compat.PackageManagerApis;
-import rikka.hidden.compat.PermissionManagerApis;
+import rikka.shizuku.server.util.Android17Compat;
 import rikka.hidden.compat.adapter.ProcessObserverAdapter;
 import rikka.hidden.compat.adapter.UidObserverAdapter;
 import rikka.shizuku.server.util.Logger;
@@ -147,14 +147,14 @@ public class BinderSender {
 
         int userId = uid / 100000;
         for (String packageName : packages) {
-            PackageInfo pi = PackageManagerApis.getPackageInfoNoThrow(packageName, PackageManager.GET_PERMISSIONS, userId);
+            PackageInfo pi = Android17Compat.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS, userId);
             if (pi == null || pi.requestedPermissions == null)
                 continue;
 
             if (ArraysKt.contains(pi.requestedPermissions, PERMISSION_MANAGER)) {
                 boolean granted;
                 if (pid == -1)
-                    granted = PermissionManagerApis.checkPermission(PERMISSION_MANAGER, uid) == PackageManager.PERMISSION_GRANTED;
+                    granted = Android17Compat.checkPermission(PERMISSION_MANAGER, uid) == PackageManager.PERMISSION_GRANTED;
                 else
                     granted = ActivityManagerApis.checkPermission(PERMISSION_MANAGER, pid, uid) == PackageManager.PERMISSION_GRANTED;
 

--- a/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import kotlin.collections.ArraysKt;
 import rikka.hidden.compat.PackageManagerApis;
 import rikka.shizuku.server.util.Android17Compat;
+import rikka.shizuku.server.util.InstalledPackagesCompat;
 import rikka.hidden.compat.UserManagerApis;
 import rikka.shizuku.server.ktx.HandlerKt;
 
@@ -149,7 +150,7 @@ public class ShizukuConfigManager extends ConfigManager {
         }
 
         for (int userId : UserManagerApis.getUserIdsNoThrow()) {
-            for (PackageInfo pi : PackageManagerApis.getInstalledPackagesNoThrow(PackageManager.GET_PERMISSIONS, userId)) {
+            for (PackageInfo pi : InstalledPackagesCompat.getInstalledPackagesNoThrow(PackageManager.GET_PERMISSIONS, userId)) {
                 if (pi == null
                         || pi.applicationInfo == null
                         || pi.requestedPermissions == null

--- a/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 import kotlin.collections.ArraysKt;
 import rikka.hidden.compat.PackageManagerApis;
-import rikka.hidden.compat.PermissionManagerApis;
+import rikka.shizuku.server.util.Android17Compat;
 import rikka.hidden.compat.UserManagerApis;
 import rikka.shizuku.server.ktx.HandlerKt;
 
@@ -160,7 +160,7 @@ public class ShizukuConfigManager extends ConfigManager {
                 int uid = pi.applicationInfo.uid;
                 boolean allowed;
                 try {
-                    allowed = PermissionManagerApis.checkPermission(PERMISSION, uid) == PackageManager.PERMISSION_GRANTED;
+                    allowed = Android17Compat.checkPermission(PERMISSION, uid) == PackageManager.PERMISSION_GRANTED;
                 } catch (Throwable e) {
                     LOGGER.w("checkPermission");
                     continue;

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -48,7 +48,7 @@ import moe.shizuku.server.IShizukuApplication;
 import rikka.hidden.compat.ActivityManagerApis;
 import rikka.hidden.compat.DeviceIdleControllerApis;
 import rikka.hidden.compat.PackageManagerApis;
-import rikka.hidden.compat.PermissionManagerApis;
+import rikka.shizuku.server.util.Android17Compat;
 import rikka.hidden.compat.UserManagerApis;
 import rikka.parcelablelist.ParcelableListSlice;
 import rikka.rish.RishConfig;
@@ -80,7 +80,7 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
     }
 
     public static ApplicationInfo getManagerApplicationInfo() {
-        return PackageManagerApis.getApplicationInfoNoThrow(MANAGER_APPLICATION_ID, 0, 0);
+        return Android17Compat.getApplicationInfo(MANAGER_APPLICATION_ID, 0, 0);
     }
 
     @SuppressWarnings({"FieldCanBeLocal"})
@@ -240,7 +240,7 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
             reply.putBoolean(BIND_APPLICATION_SHOULD_SHOW_REQUEST_PERMISSION_RATIONALE, false);
         } else {
             try {
-                PermissionManagerApis.grantRuntimePermission(MANAGER_APPLICATION_ID,
+                Android17Compat.grantRuntimePermission(MANAGER_APPLICATION_ID,
                         WRITE_SECURE_SETTINGS, UserHandleCompat.getUserId(callingUid));
             } catch (RemoteException e) {
                 LOGGER.w(e, "grant WRITE_SECURE_SETTINGS");
@@ -255,12 +255,12 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
 
     @Override
     public void showPermissionConfirmation(int requestCode, @NonNull ClientRecord clientRecord, int callingUid, int callingPid, int userId) {
-        ApplicationInfo ai = PackageManagerApis.getApplicationInfoNoThrow(clientRecord.packageName, 0, userId);
+        ApplicationInfo ai = Android17Compat.getApplicationInfo(clientRecord.packageName, 0, userId);
         if (ai == null) {
             return;
         }
 
-        PackageInfo pi = PackageManagerApis.getPackageInfoNoThrow(MANAGER_APPLICATION_ID, 0, userId);
+        PackageInfo pi = Android17Compat.getPackageInfo(MANAGER_APPLICATION_ID, 0, userId);
         UserInfo userInfo = UserManagerApis.getUserInfo(userId);
         boolean isWorkProfileUser = BuildUtils.atLeast30() ?
                 "android.os.usertype.profile.MANAGED".equals(userInfo.userType) :
@@ -320,16 +320,16 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
             int userId = UserHandleCompat.getUserId(requestUid);
 
             for (String packageName : PackageManagerApis.getPackagesForUidNoThrow(requestUid)) {
-                PackageInfo pi = PackageManagerApis.getPackageInfoNoThrow(packageName, PackageManager.GET_PERMISSIONS, userId);
+                PackageInfo pi = Android17Compat.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS, userId);
                 if (pi == null || pi.requestedPermissions == null || !ArraysKt.contains(pi.requestedPermissions, PERMISSION)) {
                     continue;
                 }
 
                 int deviceId = 0;//Context.DEVICE_ID_DEFAULT
                 if (allowed) {
-                    PermissionManagerApis.grantRuntimePermission(packageName, PERMISSION, userId);
+                    Android17Compat.grantRuntimePermission(packageName, PERMISSION, userId);
                 } else {
-                    PermissionManagerApis.revokeRuntimePermission(packageName, PERMISSION, userId);
+                    Android17Compat.revokeRuntimePermission(packageName, PERMISSION, userId);
                 }
             }
         }
@@ -344,13 +344,13 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
         if (allowRuntimePermission && (mask & ConfigManager.MASK_PERMISSION) != 0) {
             int userId = UserHandleCompat.getUserId(uid);
             for (String packageName : PackageManagerApis.getPackagesForUidNoThrow(uid)) {
-                PackageInfo pi = PackageManagerApis.getPackageInfoNoThrow(packageName, PackageManager.GET_PERMISSIONS, userId);
+                PackageInfo pi = Android17Compat.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS, userId);
                 if (pi == null || pi.requestedPermissions == null || !ArraysKt.contains(pi.requestedPermissions, PERMISSION)) {
                     continue;
                 }
 
                 try {
-                    if (PermissionManagerApis.checkPermission(PERMISSION, uid) == PackageManager.PERMISSION_GRANTED) {
+                    if (Android17Compat.checkPermission(PERMISSION, uid) == PackageManager.PERMISSION_GRANTED) {
                         return ConfigManager.FLAG_ALLOWED;
                     }
                 } catch (Throwable e) {
@@ -395,16 +395,16 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
             }
 
             for (String packageName : PackageManagerApis.getPackagesForUidNoThrow(uid)) {
-                PackageInfo pi = PackageManagerApis.getPackageInfoNoThrow(packageName, PackageManager.GET_PERMISSIONS, userId);
+                PackageInfo pi = Android17Compat.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS, userId);
                 if (pi == null || pi.requestedPermissions == null || !ArraysKt.contains(pi.requestedPermissions, PERMISSION)) {
                     continue;
                 }
 
                 int deviceId = 0;//Context.DEVICE_ID_DEFAULT
                 if (allowed) {
-                    PermissionManagerApis.grantRuntimePermission(packageName, PERMISSION, userId);
+                    Android17Compat.grantRuntimePermission(packageName, PERMISSION, userId);
                 } else {
-                    PermissionManagerApis.revokeRuntimePermission(packageName, PERMISSION, userId);
+                    Android17Compat.revokeRuntimePermission(packageName, PERMISSION, userId);
                 }
 
                 // TODO kill user service using

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -55,6 +55,7 @@ import rikka.rish.RishConfig;
 import rikka.shizuku.ShizukuApiConstants;
 import rikka.shizuku.server.api.IContentProviderUtils;
 import rikka.shizuku.server.util.HandlerUtil;
+import rikka.shizuku.server.util.InstalledPackagesCompat;
 import rikka.shizuku.server.util.UserHandleCompat;
 
 public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuClientManager, ShizukuConfigManager> {
@@ -429,7 +430,7 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
         }
 
         for (int user : users) {
-            for (PackageInfo pi : PackageManagerApis.getInstalledPackagesNoThrow(PackageManager.GET_META_DATA | PackageManager.GET_PERMISSIONS, user)) {
+            for (PackageInfo pi : InstalledPackagesCompat.getInstalledPackagesNoThrow(PackageManager.GET_META_DATA | PackageManager.GET_PERMISSIONS, user)) {
                 if (Objects.equals(MANAGER_APPLICATION_ID, pi.packageName)) continue;
                 if (pi.applicationInfo == null) continue;
 
@@ -479,7 +480,7 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
     private static void sendBinderToClient(Binder binder, int userId) {
         try {
             Stream<PackageInfo> packages =
-                PackageManagerApis.getInstalledPackagesNoThrow(
+                InstalledPackagesCompat.getInstalledPackagesNoThrow(
                     PackageManager.GET_PERMISSIONS, userId
                 )
                 .stream()

--- a/server/src/main/java/rikka/shizuku/server/ShizukuUserServiceManager.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuUserServiceManager.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import moe.shizuku.starter.ServiceStarter;
-import rikka.hidden.compat.PackageManagerApis;
+import rikka.shizuku.server.util.Android17Compat;
 import rikka.hidden.compat.UserManagerApis;
 import rikka.shizuku.server.util.UserHandleCompat;
 
@@ -49,7 +49,7 @@ public class ShizukuUserServiceManager extends UserServiceManager {
                 String newSourceDir = null;
 
                 for (int userId : UserManagerApis.getUserIdsNoThrow()) {
-                    PackageInfo pi = PackageManagerApis.getPackageInfoNoThrow(packageName, 0, userId);
+                    PackageInfo pi = Android17Compat.getPackageInfo(packageName, 0, userId);
                     if (pi != null && pi.applicationInfo != null && pi.applicationInfo.sourceDir != null) {
                         newSourceDir = pi.applicationInfo.sourceDir;
                         break;

--- a/server/src/main/java/rikka/shizuku/server/util/Android17Compat.java
+++ b/server/src/main/java/rikka/shizuku/server/util/Android17Compat.java
@@ -1,0 +1,246 @@
+package rikka.shizuku.server.util;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.os.ServiceManager;
+import android.util.Log;
+
+import java.lang.reflect.Method;
+
+import rikka.hidden.compat.PackageManagerApis;
+import rikka.hidden.compat.PermissionManagerApis;
+
+public class Android17Compat {
+
+    private static final String TAG = "ShizukuAndroid17Compat";
+    private static final int DEVICE_ID_DEFAULT = 0;
+
+    private static volatile Object sPackageManager;
+    private static volatile Method sGetPackageInfoMethod;
+    private static volatile Method sGetApplicationInfoMethod;
+
+    private static volatile Object sPermissionManager;
+    private static volatile Method sGrantRuntimePermissionMethod;
+    private static volatile Method sRevokeRuntimePermissionMethod;
+    private static volatile Method sCheckPermissionMethod;
+    private static volatile Method sCheckPermissionUidMethod;
+
+    private static synchronized Object getPackageManager() throws Exception {
+        if (sPackageManager == null) {
+            IBinder binder = ServiceManager.getService("package");
+            Class<?> stubClass = Class.forName("android.content.pm.IPackageManager$Stub");
+            sPackageManager = stubClass.getDeclaredMethod("asInterface", IBinder.class).invoke(null, binder);
+        }
+        return sPackageManager;
+    }
+
+    private static synchronized Object getPermissionManager() throws Exception {
+        if (sPermissionManager == null) {
+            IBinder binder = ServiceManager.getService("permissionmgr");
+            Class<?> stubClass = Class.forName("android.permission.IPermissionManager$Stub");
+            sPermissionManager = stubClass.getDeclaredMethod("asInterface", IBinder.class).invoke(null, binder);
+        }
+        return sPermissionManager;
+    }
+
+    public static PackageInfo getPackageInfo(String packageName, long flags, int userId) {
+        try {
+            return PackageManagerApis.getPackageInfoNoThrow(packageName, flags, userId);
+        } catch (NoSuchMethodError e) {
+            try {
+                Object pm = getPackageManager();
+                if (sGetPackageInfoMethod == null) {
+                    synchronized (Android17Compat.class) {
+                        if (sGetPackageInfoMethod == null) {
+                            sGetPackageInfoMethod = findMethod(pm, "getPackageInfo", String.class, long.class);
+                        }
+                    }
+                }
+                if (sGetPackageInfoMethod != null) {
+                    return (PackageInfo) invokeMethod(pm, sGetPackageInfoMethod, packageName, flags, userId);
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, "Android 17 fallback for getPackageInfo failed", ex);
+            }
+            return null;
+        }
+    }
+
+    public static ApplicationInfo getApplicationInfo(String packageName, long flags, int userId) {
+        try {
+            return PackageManagerApis.getApplicationInfoNoThrow(packageName, flags, userId);
+        } catch (NoSuchMethodError e) {
+            try {
+                Object pm = getPackageManager();
+                if (sGetApplicationInfoMethod == null) {
+                    synchronized (Android17Compat.class) {
+                        if (sGetApplicationInfoMethod == null) {
+                            sGetApplicationInfoMethod = findMethod(pm, "getApplicationInfo", String.class, long.class);
+                        }
+                    }
+                }
+                if (sGetApplicationInfoMethod != null) {
+                    return (ApplicationInfo) invokeMethod(pm, sGetApplicationInfoMethod, packageName, flags, userId);
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, "Android 17 fallback for getApplicationInfo failed", ex);
+            }
+            return null;
+        }
+    }
+
+    public static int checkPermission(String permissionName, String packageName, int userId) {
+        try {
+            return PermissionManagerApis.checkPermission(permissionName, packageName, userId);
+        } catch (NoSuchMethodError e) {
+            try {
+                Object pm = getPermissionManager();
+                if (sCheckPermissionMethod == null) {
+                    synchronized (Android17Compat.class) {
+                        if (sCheckPermissionMethod == null) {
+                            sCheckPermissionMethod = findMethod(pm, "checkPermission", String.class, String.class);
+                        }
+                    }
+                }
+                if (sCheckPermissionMethod != null) {
+                    return (int) invokeMethod(pm, sCheckPermissionMethod, permissionName, packageName, userId);
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, "Android 17 fallback for checkPermission(String, String, int) failed", ex);
+            }
+            return android.content.pm.PackageManager.PERMISSION_DENIED;
+        } catch (RemoteException e) {
+            return android.content.pm.PackageManager.PERMISSION_DENIED;
+        }
+    }
+
+    public static int checkPermission(String permissionName, int uid) {
+        try {
+            return PermissionManagerApis.checkPermission(permissionName, uid);
+        } catch (NoSuchMethodError e) {
+            try {
+                Object pm = getPermissionManager();
+                if (sCheckPermissionUidMethod == null) {
+                    synchronized (Android17Compat.class) {
+                        if (sCheckPermissionUidMethod == null) {
+                            sCheckPermissionUidMethod = findMethod(pm, "checkPermission", String.class, int.class);
+                        }
+                    }
+                }
+                if (sCheckPermissionUidMethod != null) {
+                    Class<?>[] paramTypes = sCheckPermissionUidMethod.getParameterTypes();
+                    if (paramTypes.length == 3 && paramTypes[1] == int.class && paramTypes[2] == int.class) {
+
+                        return (int) sCheckPermissionUidMethod.invoke(pm, permissionName, DEVICE_ID_DEFAULT, uid);
+                    }
+                    return (int) sCheckPermissionUidMethod.invoke(pm, permissionName, uid);
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, "Android 17 fallback for checkPermission(String, int) failed", ex);
+            }
+            return android.content.pm.PackageManager.PERMISSION_DENIED;
+        } catch (RemoteException e) {
+            return android.content.pm.PackageManager.PERMISSION_DENIED;
+        }
+    }
+
+    public static void grantRuntimePermission(String packageName, String permissionName, int userId) throws android.os.RemoteException {
+        try {
+            PermissionManagerApis.grantRuntimePermission(packageName, permissionName, userId);
+        } catch (NoSuchMethodError e) {
+            try {
+                Object pm = getPermissionManager();
+                if (sGrantRuntimePermissionMethod == null) {
+                    synchronized (Android17Compat.class) {
+                        if (sGrantRuntimePermissionMethod == null) {
+                            sGrantRuntimePermissionMethod = findMethod(pm, "grantRuntimePermission", String.class, String.class);
+                        }
+                    }
+                }
+                if (sGrantRuntimePermissionMethod != null) {
+                    invokeMethod(pm, sGrantRuntimePermissionMethod, packageName, permissionName, userId);
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, "Android 17 fallback for grantRuntimePermission failed", ex);
+            }
+        }
+    }
+
+    public static void revokeRuntimePermission(String packageName, String permissionName, int userId) throws android.os.RemoteException {
+        try {
+            PermissionManagerApis.revokeRuntimePermission(packageName, permissionName, userId);
+        } catch (NoSuchMethodError e) {
+            try {
+                Object pm = getPermissionManager();
+                if (sRevokeRuntimePermissionMethod == null) {
+                    synchronized (Android17Compat.class) {
+                        if (sRevokeRuntimePermissionMethod == null) {
+                            sRevokeRuntimePermissionMethod = findMethod(pm, "revokeRuntimePermission", String.class, String.class);
+                        }
+                    }
+                }
+                if (sRevokeRuntimePermissionMethod != null) {
+                    Class<?>[] paramTypes = sRevokeRuntimePermissionMethod.getParameterTypes();
+                    if (paramTypes.length == 5 && paramTypes[4] == String.class) {
+                        sRevokeRuntimePermissionMethod.invoke(pm, packageName, permissionName, DEVICE_ID_DEFAULT, userId, "shizuku");
+                    } else {
+                        invokeMethod(pm, sRevokeRuntimePermissionMethod, packageName, permissionName, userId);
+                    }
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, "Android 17 fallback for revokeRuntimePermission failed", ex);
+            }
+        }
+    }
+
+    private static Method findMethod(Object obj, String name, Class<?>... prefixTypes) {
+        Method bestMethod = null;
+        for (Method method : obj.getClass().getMethods()) {
+            if (name.equals(method.getName())) {
+                Class<?>[] paramTypes = method.getParameterTypes();
+                if (paramTypes.length >= prefixTypes.length) {
+                    boolean match = true;
+                    for (int i = 0; i < prefixTypes.length; i++) {
+                        if (paramTypes[i] != prefixTypes[i]) {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match) {
+                        if (bestMethod == null || paramTypes.length > bestMethod.getParameterTypes().length) {
+                            bestMethod = method;
+                        }
+                    }
+                }
+            }
+        }
+        return bestMethod;
+    }
+
+    private static Object invokeMethod(Object obj, Method method, Object... prefixArgs) throws Exception {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        Object[] args = new Object[paramTypes.length];
+
+        int prefixLen = prefixArgs.length - 1;
+        int userIdIdx = prefixArgs.length - 1;
+        Object userId = prefixArgs[userIdIdx];
+
+        if (paramTypes.length == prefixArgs.length + 1) {
+            System.arraycopy(prefixArgs, 0, args, 0, prefixLen);
+            args[prefixLen] = DEVICE_ID_DEFAULT;
+            args[prefixLen + 1] = userId;
+            for (int i = prefixLen + 2; i < paramTypes.length; i++) {
+                if (paramTypes[i] == int.class) args[i] = 0;
+                else if (paramTypes[i] == String.class) args[i] = null;
+            }
+        } else {
+            System.arraycopy(prefixArgs, 0, args, 0, Math.min(prefixArgs.length, paramTypes.length));
+            for (int i = prefixArgs.length; i < paramTypes.length; i++) {
+                if (paramTypes[i] == int.class) args[i] = userId;
+            }
+        }
+        return method.invoke(obj, args);
+    }
+}

--- a/server/src/main/java/rikka/shizuku/server/util/InstalledPackagesCompat.java
+++ b/server/src/main/java/rikka/shizuku/server/util/InstalledPackagesCompat.java
@@ -1,0 +1,108 @@
+package rikka.shizuku.server.util;
+
+import android.content.pm.PackageInfo;
+import android.os.Build;
+import android.util.Log;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+public final class InstalledPackagesCompat {
+
+    private static final String TAG = "InstalledPackagesCompat";
+    private static final int ANDROID_13 = 33;
+    private static final String PARCELED_LIST_SLICE = "android.content.pm.ParceledListSlice";
+
+    private InstalledPackagesCompat() {
+    }
+
+    public static List<PackageInfo> getInstalledPackagesNoThrow(long flags, int userId) {
+        try {
+            List<PackageInfo> packages = getInstalledPackages(flags, userId);
+            return packages == null ? Collections.emptyList() : packages;
+        } catch (Throwable e) {
+            Log.w(TAG, "getInstalledPackages failed", e);
+            return Collections.emptyList();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<PackageInfo> getInstalledPackages(long flags, int userId) throws ReflectiveOperationException {
+        try {
+            Object packageManager = getContextPackageManager();
+            Method method = packageManager.getClass().getMethod("getInstalledPackagesAsUser", int.class, int.class);
+            Object result = invoke(method, packageManager, (int) flags, userId);
+            return result == null ? Collections.emptyList() : (List<PackageInfo>) result;
+        } catch (NoSuchMethodException ignored) {
+        } catch (Exception e) {
+            Log.d(TAG, "getInstalledPackagesAsUser failed, falling back to hidden API", e);
+        }
+
+        Object packageManager = getPackageManager();
+        Method method;
+        Object result;
+
+        if (Build.VERSION.SDK_INT >= ANDROID_13) {
+            method = packageManager.getClass().getMethod("getInstalledPackages", long.class, int.class);
+            result = invoke(method, packageManager, flags, userId);
+        } else {
+            method = packageManager.getClass().getMethod("getInstalledPackages", int.class, int.class);
+            result = invoke(method, packageManager, (int) flags, userId);
+        }
+
+        if (result == null) {
+            return Collections.emptyList();
+        }
+
+        String resultClassName = result.getClass().getName();
+        if (resultClassName.startsWith(PARCELED_LIST_SLICE) || resultClassName.contains("PackageInfoList")) {
+            Object list = result.getClass().getMethod("getList").invoke(result);
+            return list == null ? Collections.emptyList() : (List<PackageInfo>) list;
+        }
+
+        throw new IllegalStateException("Unsupported getInstalledPackages return type: " + resultClassName);
+    }
+
+    private static Object getPackageManager() throws ReflectiveOperationException {
+        Class<?> servicesClass = Class.forName("rikka.hidden.compat.Services");
+        var field = servicesClass.getDeclaredField("packageManager");
+        field.setAccessible(true);
+        Object service = field.get(null);
+        return service.getClass().getMethod("get").invoke(service);
+    }
+
+    private static Object getContextPackageManager() throws ReflectiveOperationException {
+        Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+        Object activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
+        if (activityThread != null) {
+            Object application = activityThreadClass.getMethod("getApplication").invoke(activityThread);
+            if (application != null) {
+                return application.getClass().getMethod("getPackageManager").invoke(application);
+            }
+        }
+
+        activityThread = activityThreadClass.getMethod("systemMain").invoke(null);
+        Object systemContext = activityThreadClass.getMethod("getSystemContext").invoke(activityThread);
+        return systemContext.getClass().getMethod("getPackageManager").invoke(systemContext);
+    }
+
+    private static Object invoke(Method method, Object receiver, Object... args) throws ReflectiveOperationException {
+        try {
+            return method.invoke(receiver, args);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof ReflectiveOperationException) {
+                throw (ReflectiveOperationException) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **Note:** This change was generated with the help of an AI coding assistant.
> It has been **manually tested end-to-end on a physical device running Android 17
> QPR1 Beta 5 and Beta 6** — wireless-debugging pairing, starting Shizuku, and the
> authorized-apps list all work. Please review it as you would any external
> contribution; I'm happy to make changes.

## Summary

Android 17 changed several hidden platform APIs and tightened local-network access
(Local Network Protection), which broke wireless-debugging setup and the manager's
app list on this fork. This PR restores full functionality on Android 17 while
remaining backward-compatible with older releases. The approach mirrors the
Nightzuku fork's Android 17 work.

## What was broken on Android 17, and how it's fixed

**1. Wireless ADB pairing hung at "scanning"**
The adb pairing daemon now advertises (via mDNS) and binds to the device's
local-network address rather than loopback. `AdbMdns` hardcoded `127.0.0.1`, so its
port-availability probe checked the wrong address and the pairing client connected
to the wrong host.
→ `AdbMdns` now reports the resolved host alongside the port and connects/probes on
that host. The host is threaded through the pairing-service reply Intent so it
survives a service restart.

**2. Endless "Choose a device to connect" system picker**
`ACCESS_LOCAL_NETWORK` was declared but never requested at runtime, so Android 17
intercepted every LAN connection with a per-connection device picker that never
resolved.
→ `AdbPairingTutorialActivity` now requests the local-network runtime permission
(`ACCESS_LOCAL_NETWORK` on SDK 37, `NEARBY_WIFI_DEVICES` on SDK 36) before starting
the pairing service, so the OS shows a normal one-time grant instead.

**3. Authorized-apps list was empty**
The app list still called the raw hidden `PackageManager.getInstalledPackages`,
whose signature changed on Android 17, so it returned nothing.
→ New `InstalledPackagesCompat` tries `getInstalledPackagesAsUser` and falls back to
the hidden `IPackageManager.getInstalledPackages` (long-flags on Android 13+, with
`ParceledListSlice`/`PackageInfoList` unwrapping). The three server call sites and
the manager's `ShizukuSystemApis` are routed through it.

**4. Privileged package/permission lookups on Android 17**
→ New `Android17Compat` reflection wrapper around the hidden PackageManager/
PermissionManager APIs, falling back to the Android 17 device-id-aware signatures.
`ShizukuService`, `BinderSender`, `ShizukuConfigManager`, and
`ShizukuUserServiceManager` route their privileged lookups through it.

## Build / manifest changes

- `compileSdk`/`targetSdk` → 37, `buildToolsVersion` → 37.0.0.
- New permissions in the manager manifest: `ACCESS_LOCAL_NETWORK`,
  `USE_LOOPBACK_INTERFACE`, `CHANGE_WIFI_MULTICAST_STATE`, and
  `NEARBY_WIFI_DEVICES` (neverForLocation).
- A `build.gradle.compileSdk36` fallback is included for building against SDK 36 if
  an SDK 37 toolchain isn't available.

## Testing

Built as a debug APK via CI and installed on a physical device running **Android 17
QPR1 Beta 5 and Beta 6**:
- ✅ Wireless-debugging pairing completes
- ✅ Shizuku starts and runs ("Shizuku is running")
- ✅ Authorized-apps list populates and manages apps correctly

## Not included

The Nightzuku "NightDog" server watchdog is intentionally left out to keep this PR
focused on Android 17 compatibility.