### PR TITLE
Fix #188 (stale ADB TCP port on boot) and #237 (TCP torn down on background start)

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -63,12 +63,6 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                 Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
                 Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
             }
-        
-            val adbEnabled = Settings.Global.getInt(cr, Settings.Global.ADB_ENABLED, 0)
-            if (adbEnabled == 0) {
-                WadbEnableUsbDebuggingDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
-                return
-            }
 
             // #188: the manual Start path direct-connects to this port (the else
             // branch below), so it must be a LIVE port, never the possibly stale
@@ -78,6 +72,18 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
             val tcpPort = EnvironmentUtils.getLiveAdbTcpPort()
             val tcpMode = ShizukuSettings.getTcpMode()
 
+            // #204: the wireless Start path needs WIRELESS debugging, not USB debugging.
+            // Only warn about USB debugging when there is genuinely no ADB access at all
+            // -- no USB debugging, no wireless debugging, and no live TCP port. A
+            // non-privileged read of adb_enabled returns 0 on some ROMs even when USB
+            // debugging is on, which previously blocked a valid wireless start right
+            // after a successful pairing.
+            val adbEnabled = Settings.Global.getInt(cr, Settings.Global.ADB_ENABLED, 0)
+            val adbWifiEnabled = Settings.Global.getInt(cr, "adb_wifi_enabled", 0)
+            if (adbEnabled == 0 && adbWifiEnabled == 0 && tcpPort <= 0) {
+                WadbEnableUsbDebuggingDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
+                return
+            }
             // If ADB is NOT listening to a TCP port and the device doesn't support TLS, inform the user
             if (tcpPort <= 0 && !EnvironmentUtils.isTlsSupported()) {
                 WadbNotEnabledDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
@@ -100,14 +106,8 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                 scope.launch {
                     val live = EnvironmentUtils.isAdbPortLive("127.0.0.1", tcpPort)
                     withContext(Dispatchers.Main) {
-                        // The probe can take up to a second. `scope` is the Activity's
-                        // lifecycleScope, which is cancelled on destroy but NOT on stop --
-                        // so if the user backgrounded the screen (or a config change saved
-                        // state) during that window, we'd still resume here. Touching the UI
-                        // now would crash: FragmentManager#show throws
-                        // IllegalStateException after onSaveInstanceState, and a background
-                        // startActivity is blocked on Android 10+. Bail; the user can tap
-                        // Start again when they return.
+                        // lifecycleScope survives onStop; bail if state was saved during
+                        // the probe so show()/startActivity can't crash (#188).
                         if (activity.isFinishing || activity.supportFragmentManager.isStateSaved) {
                             return@withContext
                         }

--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -69,7 +69,12 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                 return
             }
 
-            val tcpPort = EnvironmentUtils.getAdbTcpPort()
+            // #188: the manual Start path direct-connects to this port (the else
+            // branch below), so it must be a LIVE port, never the possibly stale
+            // persist.adb.tcp.port. getLiveAdbTcpPort() excludes that persisted
+            // fallback (keeping the non-TLS-TV configured-port fallback), so on boot
+            // we route to mDNS rediscovery instead of dialing a dead port.
+            val tcpPort = EnvironmentUtils.getLiveAdbTcpPort()
             val tcpMode = ShizukuSettings.getTcpMode()
 
             // If ADB is NOT listening to a TCP port and the device doesn't support TLS, inform the user

--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -96,15 +96,27 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
             // (#188). Probe it off the main thread; direct-connect only if it answers,
             // otherwise re-discover over mDNS instead of launching a doomed start.
             } else {
+                val activity = context.asActivity<FragmentActivity>()
                 scope.launch {
                     val live = EnvironmentUtils.isAdbPortLive("127.0.0.1", tcpPort)
                     withContext(Dispatchers.Main) {
+                        // The probe can take up to a second. `scope` is the Activity's
+                        // lifecycleScope, which is cancelled on destroy but NOT on stop --
+                        // so if the user backgrounded the screen (or a config change saved
+                        // state) during that window, we'd still resume here. Touching the UI
+                        // now would crash: FragmentManager#show throws
+                        // IllegalStateException after onSaveInstanceState, and a background
+                        // startActivity is blocked on Android 10+. Bail; the user can tap
+                        // Start again when they return.
+                        if (activity.isFinishing || activity.supportFragmentManager.isStateSaved) {
+                            return@withContext
+                        }
                         if (live) {
-                            context.startActivity(Intent(context, StarterActivity::class.java).apply {
+                            activity.startActivity(Intent(activity, StarterActivity::class.java).apply {
                                 putExtra(StarterActivity.EXTRA_PORT, tcpPort)
                             })
                         } else {
-                            AdbDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
+                            AdbDialogFragment().show(activity.supportFragmentManager)
                         }
                     }
                 }

--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -18,6 +18,7 @@ import androidx.work.WorkManager
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import moe.shizuku.manager.Helps
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.R
@@ -89,12 +90,24 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                     AdbStarter.stopTcp(context, tcpPort)
                 }
                 AdbDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
-            // Otherwise ADB IS listening to a TCP port and the user wants to keep it open. Start Shizuku via TCP
+            // Otherwise ADB looks like it's listening on a TCP port and the user wants to
+            // keep it open. But the property value alone isn't proof adbd is actually
+            // listening -- on some ROMs service.adb.tcp.port holds a dead port after boot
+            // (#188). Probe it off the main thread; direct-connect only if it answers,
+            // otherwise re-discover over mDNS instead of launching a doomed start.
             } else {
-                val intent = Intent(context, StarterActivity::class.java).apply {
-                    putExtra(StarterActivity.EXTRA_PORT, tcpPort)
+                scope.launch {
+                    val live = EnvironmentUtils.isAdbPortLive("127.0.0.1", tcpPort)
+                    withContext(Dispatchers.Main) {
+                        if (live) {
+                            context.startActivity(Intent(context, StarterActivity::class.java).apply {
+                                putExtra(StarterActivity.EXTRA_PORT, tcpPort)
+                            })
+                        } else {
+                            AdbDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
+                        }
+                    }
                 }
-                context.startActivity(intent)
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -9,6 +9,10 @@ import android.os.SystemProperties
 import moe.shizuku.manager.ShizukuApplication
 import moe.shizuku.manager.ShizukuSettings
 import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetSocketAddress
+import java.net.Socket
 
 private val appContext = ShizukuApplication.appContext
 
@@ -64,5 +68,26 @@ object EnvironmentUtils {
         var port = SystemProperties.getInt("service.adb.tcp.port", -1)
         if (port == -1 && isTelevision() && !isTlsSupported()) port = ShizukuSettings.getTcpPort()
         return port
+    }
+
+    /**
+     * Whether adbd is *actually* listening on [port] right now, verified by a real
+     * connect with a short [timeoutMs]. A non-stale property value is still not proof
+     * of liveness: on some ROMs `service.adb.tcp.port` itself holds a dead port after
+     * boot (#188 -- the reporter's returned 6776 while every connect failed). So knock
+     * before trusting it; a refused/dead port returns false and the caller should fall
+     * back to mDNS re-discovery. (Approach thedjchi described on #188: connect with a
+     * timeout to verify the port is valid before taking it.)
+     */
+    suspend fun isAdbPortLive(host: String, port: Int, timeoutMs: Int = 1000): Boolean {
+        if (port <= 0) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -34,7 +34,7 @@ object EnvironmentUtils {
     }
 
     fun isWifiRequired(): Boolean {
-        return (getAdbTcpPort() <= 0 || !ShizukuSettings.getTcpMode())
+        return (getLiveAdbTcpPort() <= 0 || !ShizukuSettings.getTcpMode())
     }
 
     fun isRooted(): Boolean {
@@ -44,6 +44,24 @@ object EnvironmentUtils {
     fun getAdbTcpPort(): Int {
         var port = SystemProperties.getInt("service.adb.tcp.port", -1)
         if (port == -1) port = SystemProperties.getInt("persist.adb.tcp.port", -1)
+        if (port == -1 && isTelevision() && !isTlsSupported()) port = ShizukuSettings.getTcpPort()
+        return port
+    }
+
+    /**
+     * The ADB TCP port that is safe to connect to WITHOUT first re-discovering it
+     * over mDNS. Unlike [getAdbTcpPort], this deliberately excludes
+     * `persist.adb.tcp.port`: that property survives a reboot but adbd does not
+     * necessarily relisten on it, so on boot it is frequently a stale/dead port.
+     * Trusting it there made the start path skip discovery and connect to a dead
+     * port, failing every start until wireless debugging was toggled once (#188).
+     *
+     * `service.adb.tcp.port` is volatile (set only while adbd is actively listening
+     * on TCP), so it is a real liveness signal. Non-TLS TVs cannot use mDNS
+     * discovery, so their configured port stays a valid direct target.
+     */
+    fun getLiveAdbTcpPort(): Int {
+        var port = SystemProperties.getInt("service.adb.tcp.port", -1)
         if (port == -1 && isTelevision() && !isTlsSupported()) port = ShizukuSettings.getTcpPort()
         return port
     }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -53,7 +53,11 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
             Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
 
-            val tcpPort = EnvironmentUtils.getAdbTcpPort()
+            // Connect only to a LIVE port; never the possibly-stale persisted one.
+            // getLiveAdbTcpPort() excludes persist.adb.tcp.port (keeping the non-TLS
+            // TV configured-port fallback), so phones route to discovery, TVs use
+            // their configured port, and neither trusts a stale value (#188).
+            val tcpPort = EnvironmentUtils.getLiveAdbTcpPort()
 
             val port = tcpPort.takeIf { !EnvironmentUtils.isWifiRequired() } ?: callbackFlow {
                 val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -54,9 +54,6 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
 
             val tcpPort = EnvironmentUtils.getAdbTcpPort()
-            if (tcpPort > 0 && !ShizukuSettings.getTcpMode()) {
-                AdbStarter.stopTcp(applicationContext, tcpPort)
-            }
 
             val port = tcpPort.takeIf { !EnvironmentUtils.isWifiRequired() } ?: callbackFlow {
                 val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -53,13 +53,18 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
             Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
 
-            // Connect only to a LIVE port; never the possibly-stale persisted one.
-            // getLiveAdbTcpPort() excludes persist.adb.tcp.port (keeping the non-TLS
-            // TV configured-port fallback), so phones route to discovery, TVs use
-            // their configured port, and neither trusts a stale value (#188).
+            // Connect only to a port adbd is *actually* listening on. getLiveAdbTcpPort()
+            // already drops the possibly-stale persist.adb.tcp.port, but even the live
+            // property can be stale on some ROMs (#188: the reporter's service.adb.tcp.port
+            // held a dead 6776 while every connect failed). So probe the candidate with a
+            // short connect timeout and only take it if it answers; otherwise fall through
+            // to mDNS re-discovery. (Approach thedjchi described on #188.)
             val tcpPort = EnvironmentUtils.getLiveAdbTcpPort()
+            val directPort =
+                if (!EnvironmentUtils.isWifiRequired() && EnvironmentUtils.isAdbPortLive("127.0.0.1", tcpPort))
+                    tcpPort else -1
 
-            val port = tcpPort.takeIf { !EnvironmentUtils.isWifiRequired() } ?: callbackFlow {
+            val port = directPort.takeIf { it > 0 } ?: callbackFlow {
                 val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->
                     if (p.second > 0) trySend(p.second)
                 }


### PR DESCRIPTION
Two small, related fixes in the wireless-ADB start path (both in `AdbStartWorker` / `EnvironmentUtils`), as two atomic commits.

## fix #188 — stale ADB TCP port on boot
`getAdbTcpPort()` falls back to `persist.adb.tcp.port`, which survives a reboot even though adbd does not necessarily relisten on it. The start path treats any positive value as "we have a port, skip mDNS discovery" — so on boot a stale persisted value makes Shizuku connect straight to a dead port and fail every start until wireless debugging is toggled once (reported on Android 15).

Fix: add `getLiveAdbTcpPort()`, which reads only `service.adb.tcp.port` (volatile — set solely while adbd is actively listening on TCP, a real liveness signal) and keeps the non-TLS-TV configured-port fallback. Both the skip-discovery decision (`isWifiRequired`) and the actual connect target use it, so when only a stale persisted hint exists the worker routes to discovery instead of dialing a dead port. SDK-agnostic — no loopback liveness probe (which would be wrong on Android 17, where the wireless endpoint isn't loopback).

## fix #237 — TCP torn down on every background start
`AdbStartWorker` called `AdbStarter.stopTcp` on every background start whenever TCP mode was off and a port was configured, clobbering an externally-managed `adb tcpip`. Teardown belongs solely to the explicit user toggle-off, which `SettingsFragment.promptStopTcp` already handles. Removed it from the background start path so Shizuku only disables TCP when the user asks for it (toggle-off still tears down, toggle-on still reopens — unchanged).

## Validation
Both verified with deterministic baseline-vs-fixed emulator A/B runs:
- #188 (Android 11, real reboot): baseline seeds a stale `persist.adb.tcp.port`, it survives the reboot, and connects to the dead port; the fix rejects it and routes to discovery. Confirmed coherent on the TV path (non-TLS TV uses its configured port, not the stale one).
- #237: baseline calls `stopTcp` on a background start; the fix does not, while the toggle-off teardown is unchanged.

The diff is intentionally minimal — two files, no new dependencies.