### PR TITLE
Warn when Watchdog is enabled but TCP mode is off

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
@@ -206,6 +206,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             }
         }
 
+        refreshWatchdogSummary()
+
         tcpPortPreference.apply {
             isVisible = tcpModePreference.isVisible && tcpModePreference.isChecked
             icon = maybeGetRestartIcon(KEY_TCP_PORT)
@@ -339,6 +341,19 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         when (key) {
             KEY_WATCHDOG -> watchdogPreference.isChecked = ShizukuSettings.isWatchdogRunning()
         }
+        if (key == KEY_WATCHDOG || key == KEY_TCP_MODE) refreshWatchdogSummary()
+    }
+
+    // Warn when the watchdog is on but TCP mode is off. In that combination the
+    // watchdog can only recover Shizuku over Wi-Fi -- it just re-runs the normal
+    // start, which needs mDNS discovery -- and never on cellular. TCP mode's fixed
+    // loopback port is what makes off-Wi-Fi recovery possible, so surface that.
+    private fun refreshWatchdogSummary() {
+        val base = getString(R.string.settings_watchdog_summary)
+        val warn = watchdogPreference.isChecked && !ShizukuSettings.getTcpMode()
+        watchdogPreference.summary =
+            if (warn) "$base\n\n⚠ ${getString(R.string.settings_watchdog_no_tcp_warning)}"
+            else base
     }
 
     override fun onCreateRecyclerView(

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="settings_use_system_color">Use system theme color</string>
     <string name="settings_watchdog">Watchdog</string>
     <string name="settings_watchdog_summary">Automatically restart Shizuku if it crashes</string>
+    <string name="settings_watchdog_no_tcp_warning">Without TCP mode, the watchdog can\'t recover Shizuku on cellular data — only on Wi-Fi. Enable TCP mode for recovery on any network.</string>
     <string name="settings_tcp_mode">TCP mode</string>
     <string name="settings_tcp_mode_summary">"Allows Shizuku to restart without Wi-Fi. (Shizuku must have started once since reboot)"</string>
     <string name="settings_tcp_mode_dialog_close_port">"The TCP port will be closed immediately. You will need Wi-Fi to turn on TCP mode again. Continue?"</string>


### PR DESCRIPTION
### Problem
The Watchdog recovers Shizuku by re-running the normal start path (`ShizukuReceiverStarter.start()` on `CRASHED`). In **non-TCP mode** that start needs Wi-Fi + mDNS discovery to find the random, per-session wireless-debugging port. So with **Watchdog on but TCP mode off**, Shizuku silently **cannot be recovered on cellular data** (only on Wi-Fi), with no indication to the user. TCP mode's fixed loopback port (`tcpip:5555`) is what makes off-Wi-Fi recovery possible.

### Change
When the Watchdog is enabled **and** TCP mode is disabled, append a warning to the Watchdog setting's summary:

> Without TCP mode, the watchdog can't recover Shizuku on cellular data (only on Wi-Fi). Enable TCP mode for recovery on any network.

The summary refreshes when either toggle changes. **Pure UX, no behavior change.**

### Notes
- Reuses the existing `settings_watchdog_summary`; adds one string and a small `refreshWatchdogSummary()` helper.
- Only appears where TCP mode is a real choice (TLS-capable). TV/legacy keep TCP mode effectively on, so the warning never shows there