### PR TITLE
fix(#204): don't block wireless start on the USB-debugging setting

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -63,14 +63,21 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                 Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
             }
         
+            val tcpPort = EnvironmentUtils.getAdbTcpPort()
+            val tcpMode = ShizukuSettings.getTcpMode()
+
+            // #204: the wireless Start path needs WIRELESS debugging, not USB debugging.
+            // Only warn about USB debugging when there is genuinely no ADB access at all
+            // -- no USB debugging, no wireless debugging, and no live TCP port. A
+            // non-privileged read of adb_enabled returns 0 on some ROMs even when USB
+            // debugging is on, which previously blocked a valid wireless start right
+            // after a successful pairing.
             val adbEnabled = Settings.Global.getInt(cr, Settings.Global.ADB_ENABLED, 0)
-            if (adbEnabled == 0) {
+            val adbWifiEnabled = Settings.Global.getInt(cr, "adb_wifi_enabled", 0)
+            if (adbEnabled == 0 && adbWifiEnabled == 0 && tcpPort <= 0) {
                 WadbEnableUsbDebuggingDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
                 return
             }
-
-            val tcpPort = EnvironmentUtils.getAdbTcpPort()
-            val tcpMode = ShizukuSettings.getTcpMode()
 
             // If ADB is NOT listening to a TCP port and the device doesn't support TLS, inform the user
             if (tcpPort <= 0 && !EnvironmentUtils.isTlsSupported()) {

--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -18,6 +18,7 @@ import androidx.work.WorkManager
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import moe.shizuku.manager.Helps
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.R
@@ -62,8 +63,13 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                 Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
                 Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
             }
-        
-            val tcpPort = EnvironmentUtils.getAdbTcpPort()
+
+            // #188: the manual Start path direct-connects to this port (the else
+            // branch below), so it must be a LIVE port, never the possibly stale
+            // persist.adb.tcp.port. getLiveAdbTcpPort() excludes that persisted
+            // fallback (keeping the non-TLS-TV configured-port fallback), so on boot
+            // we route to mDNS rediscovery instead of dialing a dead port.
+            val tcpPort = EnvironmentUtils.getLiveAdbTcpPort()
             val tcpMode = ShizukuSettings.getTcpMode()
 
             // #204: the wireless Start path needs WIRELESS debugging, not USB debugging.
@@ -78,7 +84,6 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                 WadbEnableUsbDebuggingDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
                 return
             }
-
             // If ADB is NOT listening to a TCP port and the device doesn't support TLS, inform the user
             if (tcpPort <= 0 && !EnvironmentUtils.isTlsSupported()) {
                 WadbNotEnabledDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
@@ -91,12 +96,30 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
                     AdbStarter.stopTcp(context, tcpPort)
                 }
                 AdbDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
-            // Otherwise ADB IS listening to a TCP port and the user wants to keep it open. Start Shizuku via TCP
+            // Otherwise ADB looks like it's listening on a TCP port and the user wants to
+            // keep it open. But the property value alone isn't proof adbd is actually
+            // listening -- on some ROMs service.adb.tcp.port holds a dead port after boot
+            // (#188). Probe it off the main thread; direct-connect only if it answers,
+            // otherwise re-discover over mDNS instead of launching a doomed start.
             } else {
-                val intent = Intent(context, StarterActivity::class.java).apply {
-                    putExtra(StarterActivity.EXTRA_PORT, tcpPort)
+                val activity = context.asActivity<FragmentActivity>()
+                scope.launch {
+                    val live = EnvironmentUtils.isAdbPortLive("127.0.0.1", tcpPort)
+                    withContext(Dispatchers.Main) {
+                        // lifecycleScope survives onStop; bail if state was saved during
+                        // the probe so show()/startActivity can't crash (#188).
+                        if (activity.isFinishing || activity.supportFragmentManager.isStateSaved) {
+                            return@withContext
+                        }
+                        if (live) {
+                            activity.startActivity(Intent(activity, StarterActivity::class.java).apply {
+                                putExtra(StarterActivity.EXTRA_PORT, tcpPort)
+                            })
+                        } else {
+                            AdbDialogFragment().show(activity.supportFragmentManager)
+                        }
+                    }
                 }
-                context.startActivity(intent)
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -9,6 +9,10 @@ import android.os.SystemProperties
 import moe.shizuku.manager.ShizukuApplication
 import moe.shizuku.manager.ShizukuSettings
 import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetSocketAddress
+import java.net.Socket
 
 private val appContext = ShizukuApplication.appContext
 
@@ -34,7 +38,7 @@ object EnvironmentUtils {
     }
 
     fun isWifiRequired(): Boolean {
-        return (getAdbTcpPort() <= 0 || !ShizukuSettings.getTcpMode())
+        return (getLiveAdbTcpPort() <= 0 || !ShizukuSettings.getTcpMode())
     }
 
     fun isRooted(): Boolean {
@@ -46,5 +50,44 @@ object EnvironmentUtils {
         if (port == -1) port = SystemProperties.getInt("persist.adb.tcp.port", -1)
         if (port == -1 && isTelevision() && !isTlsSupported()) port = ShizukuSettings.getTcpPort()
         return port
+    }
+
+    /**
+     * The ADB TCP port that is safe to connect to WITHOUT first re-discovering it
+     * over mDNS. Unlike [getAdbTcpPort], this deliberately excludes
+     * `persist.adb.tcp.port`: that property survives a reboot but adbd does not
+     * necessarily relisten on it, so on boot it is frequently a stale/dead port.
+     * Trusting it there made the start path skip discovery and connect to a dead
+     * port, failing every start until wireless debugging was toggled once (#188).
+     *
+     * `service.adb.tcp.port` is volatile (set only while adbd is actively listening
+     * on TCP), so it is a real liveness signal. Non-TLS TVs cannot use mDNS
+     * discovery, so their configured port stays a valid direct target.
+     */
+    fun getLiveAdbTcpPort(): Int {
+        var port = SystemProperties.getInt("service.adb.tcp.port", -1)
+        if (port == -1 && isTelevision() && !isTlsSupported()) port = ShizukuSettings.getTcpPort()
+        return port
+    }
+
+    /**
+     * Whether adbd is *actually* listening on [port] right now, verified by a real
+     * connect with a short [timeoutMs]. A non-stale property value is still not proof
+     * of liveness: on some ROMs `service.adb.tcp.port` itself holds a dead port after
+     * boot (#188 -- the reporter's returned 6776 while every connect failed). So knock
+     * before trusting it; a refused/dead port returns false and the caller should fall
+     * back to mDNS re-discovery. (Approach thedjchi described on #188: connect with a
+     * timeout to verify the port is valid before taking it.)
+     */
+    suspend fun isAdbPortLive(host: String, port: Int, timeoutMs: Int = 1000): Boolean {
+        if (port <= 0) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
     }
 }


### PR DESCRIPTION
The manual "Start" button (wireless flow) hard-failed with "USB debugging is not enabled" whenever Settings.Global.ADB_ENABLED read 0. But the wireless path needs WIRELESS debugging (adb_wifi_enabled), not USB debugging, and a non-privileged read of adb_enabled returns 0 on some ROMs (e.g. LineageOS) even when USB debugging is actually on -- so a valid start right after a successful pairing was blocked. Upstream RikkaApps has no such gate, matching the report that it only happens on this fork.

Only show the "enable USB debugging" dialog when there is genuinely no ADB access at all: no USB debugging, no wireless debugging, and no live TCP port. Otherwise fall through to the existing TCP-port / mDNS-discovery handling.


Claude-Session: https://claude.ai/code/session_01FojD6NPVebdqS65f8e3GVx