### PR TITLE
fix(#221): disable USB debugging after a reboot when auto-disable is on

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -224,6 +224,18 @@
             </intent-filter>
         </receiver>
 
+        <!-- #221: reconciles "Auto-disable USB debugging" after a reboot. Always
+             enabled (BootCompleteReceiver's enabled state is start-on-boot's source
+             of truth, so it can't be reused); no-ops when the setting is off. -->
+        <receiver
+            android:name=".receiver.AutoDisableUsbDebuggingReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
         <receiver
             android:name=".receiver.ManualStartReceiver"
             android:enabled="true"

--- a/manager/src/main/java/moe/shizuku/manager/receiver/AutoDisableUsbDebuggingReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/AutoDisableUsbDebuggingReceiver.kt
@@ -1,0 +1,36 @@
+package moe.shizuku.manager.receiver
+
+import android.Manifest.permission.WRITE_SECURE_SETTINGS
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
+import moe.shizuku.manager.ShizukuSettings
+
+/**
+ * #221: When "Auto-disable USB debugging" is on, a reboot leaves USB debugging
+ * enabled. The disable only runs from [ShizukuStateMachine.setDead] on an explicit
+ * STOPPING transition; a reboot instead kills the process (no orderly stop, no
+ * STOPPING state), so it never fires and USB debugging stays on after boot.
+ *
+ * Reconcile at boot: if the setting is on and Shizuku is NOT going to be
+ * (re)started on boot -- i.e. start-on-boot is off, so nothing needs USB debugging
+ * -- disable it now. When start-on-boot is on, [BootCompleteReceiver] restarts
+ * Shizuku (which needs USB debugging), so we leave it alone.
+ *
+ * This receiver is always enabled (unlike [BootCompleteReceiver], whose enabled
+ * state is start-on-boot's source of truth via [ShizukuSettings.getStartOnBoot]);
+ * it no-ops cheaply when the setting is off.
+ */
+class AutoDisableUsbDebuggingReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        ShizukuSettings.initialize(context)
+        if (!ShizukuSettings.getAutoDisableUsbDebugging()) return
+        // start-on-boot on -> Shizuku will restart and needs USB debugging; leave it.
+        if (ShizukuSettings.getStartOnBoot(context)) return
+        if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) return
+        Settings.Global.putInt(context.contentResolver, Settings.Global.ADB_ENABLED, 0)
+    }
+}


### PR DESCRIPTION
"Auto-disable USB debugging" only ran from ShizukuStateMachine.setDead() on an explicit STOPPING transition. A reboot never reaches STOPPING (it maps RUNNING -> CRASHED) and kills the process outright, so the disable never fired and USB debugging stayed enabled after boot.

Add AutoDisableUsbDebuggingReceiver, an always-enabled BOOT_COMPLETED receiver that reconciles at boot: when the setting is on and start-on-boot is off (so nothing will (re)start Shizuku and need USB debugging), disable it. When start-on-boot is on, BootCompleteReceiver restarts Shizuku, so it's left alone. A dedicated receiver is used because BootCompleteReceiver's enabled state is the source of truth for start-on-boot (getStartOnBoot) and cannot be reused.


Claude-Session: https://claude.ai/code/session_01FojD6NPVebdqS65f8e3GVx