### PR TITLE
fix(#134): use on-surface text color for the "Toggle all" row

### DIFF
--- a/manager/src/main/res/layout/app_list_toggle_all.xml
+++ b/manager/src/main/res/layout/app_list_toggle_all.xml
@@ -33,7 +33,7 @@
             android:layout_weight="1"
             android:text="@string/app_management_toggle_all"
             android:textAppearance="?textAppearanceBodyLarge"
-            android:textColor="?colorOnSecondaryContainer"
+            android:textColor="?textColorOnSurfaceHighEmphasis"
             android:clickable="false"
             android:focusable="false" />
 


### PR DESCRIPTION
Fixes thedjchi/Shizuku#134

The "Toggle all" label sits on a ?colorSurfaceContainerLow card but drew its text with ?colorOnSecondaryContainer — the on-color paired with colorSecondaryContainer, a different surface. On a surface-container background that pairing has no guaranteed contrast, and under Material You dynamic palettes it reads fine on some wallpapers and washes out on others — matching the device-dependent "low contrast, only sometimes" report.

Use ?textColorOnSurfaceHighEmphasis, the same high-emphasis on-surface color the sibling app rows (app_list_item.xml) already use, so the label has proper contrast in both light and dark and matches the rest of the list