### PR TITLE
Add HeadlessLogger for headless operation diagnostics

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.service.WatchdogService
+import moe.shizuku.manager.utils.HeadlessLogger
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import rikka.core.util.BuildUtils.atLeast30
@@ -40,6 +41,7 @@ class ShizukuApplication : Application() {
 
     private fun init(context: Context) {
         ShizukuSettings.initialize(context)
+        HeadlessLogger.init(context)
         LocaleDelegate.defaultLocale = ShizukuSettings.getLocale()
         AppCompatDelegate.setDefaultNightMode(ShizukuSettings.getNightMode())
 

--- a/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
@@ -1,0 +1,68 @@
+package moe.shizuku.manager.utils
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object HeadlessLogger {
+
+    private const val TAG = "ShizukuHeadless"
+    private const val LOG_FILE = "headless.log"
+    private const val MAX_SIZE = 256 * 1024
+
+    private var logDir: File? = null
+    private var logFile: File? = null
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+
+    enum class Level { INFO, WARN, ERROR }
+
+    fun init(context: Context) {
+        if (logDir != null) return
+        logDir = context.getExternalFilesDir(null) ?: context.filesDir
+        logDir?.mkdirs()
+        logFile = logDir?.let { File(it, LOG_FILE) }
+    }
+
+    fun i(component: String, message: String) = log(Level.INFO, component, message)
+    fun w(component: String, message: String) = log(Level.WARN, component, message)
+    fun e(component: String, message: String, throwable: Throwable? = null) {
+        val msg = if (throwable != null) {
+            val sw = StringWriter()
+            throwable.printStackTrace(PrintWriter(sw))
+            "$message\n${sw.toString()}"
+        } else message
+        log(Level.ERROR, component, msg)
+    }
+
+    @Synchronized
+    private fun log(level: Level, component: String, message: String) {
+        val ts = dateFormat.format(Date())
+        val line = "$ts ${level.name.padEnd(5)} $component: $message"
+
+        Log.println(level.toLogPriority(), TAG, "$component: $message")
+
+        val file = logFile ?: return
+        try {
+            if (file.length() > MAX_SIZE) {
+                file.renameTo(File(file.parent, LOG_FILE + ".1"))
+            }
+            FileWriter(file, true).use { it.appendLine(line) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Cannot write log file: ${e.message}")
+        }
+    }
+
+    fun getLogPath(): String? = logFile?.absolutePath
+
+    private fun Level.toLogPriority(): Int = when (this) {
+        Level.INFO -> Log.INFO
+        Level.WARN -> Log.WARN
+        Level.ERROR -> Log.ERROR
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
@@ -45,7 +45,11 @@ object HeadlessLogger {
         val ts = dateFormat.format(Date())
         val line = "$ts ${level.name.padEnd(5)} $component: $message"
 
-        Log.println(level.toLogPriority(), TAG, "$component: $message")
+        when (level) {
+            Level.INFO -> Log.i(TAG, "$component: $message")
+            Level.WARN -> Log.w(TAG, "$component: $message")
+            Level.ERROR -> Log.e(TAG, "$component: $message")
+        }
 
         val file = logFile ?: return
         try {
@@ -59,10 +63,4 @@ object HeadlessLogger {
     }
 
     fun getLogPath(): String? = logFile?.absolutePath
-
-    private fun Level.toLogPriority(): Int = when (this) {
-        Level.INFO -> Log.INFO
-        Level.WARN -> Log.WARN
-        Level.ERROR -> Log.ERROR
-    }
 }


### PR DESCRIPTION

> **Note:** This work was done primarily by AI. A human did some testing, but then decided to move away from AutoJs6 to a compiled Kotlin APK. As a result, these PRs are mostly just FYI and not necessarily in shape for direct merging. I thought it would be more useful to share them rather than letting them sit there, in the hope they may be of some use.

Adds a structured logger that writes to both logcat (tag ShizukuHeadless) and a file at the app's external files directory. Format follows Unix conventions: 'YYYY-MM-DD HH:MM:SS LEVEL component: message'.

Initialized during ShizukuApplication.onCreate() so it is available before any boot-time broadcast receivers fire.

This is a foundational utility used by subsequent PRs for headless operation logging (headless start/stop, status, boot retry, auth provisioning).