### PR TITLE
Accept shell/root callers in AuthenticatedReceiver

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/receiver/AuthenticatedReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/AuthenticatedReceiver.kt
@@ -6,6 +6,8 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Binder
+import android.os.Process
 import androidx.core.app.NotificationCompat
 import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
@@ -23,7 +25,9 @@ abstract class AuthenticatedReceiver : BroadcastReceiver() {
         val authToken = intent.getStringExtra("auth")
         val expectedToken = ShizukuSettings.getAuthToken()
 
-        if (authToken.isNullOrEmpty()) {
+        if (isPrivilegedCaller()) {
+            onAuthenticated(context, intent)
+        } else if (authToken.isNullOrEmpty()) {
             context.notify(
                 R.string.notification_auth_missing_title,
                 R.string.notification_auth_missing_message
@@ -36,6 +40,12 @@ abstract class AuthenticatedReceiver : BroadcastReceiver() {
         } else {
             onAuthenticated(context, intent)
         }
+    }
+
+    private fun isPrivilegedCaller(): Boolean {
+        val callingUid = Binder.getCallingUid()
+        return callingUid == Process.SHELL_UID ||
+                callingUid == Process.ROOT_UID
     }
 
     private fun Context.notify(title: Int, message: Int) {

--- a/manager/src/main/java/moe/shizuku/manager/receiver/AuthenticatedReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/AuthenticatedReceiver.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Binder
 import android.os.Process
 import androidx.core.app.NotificationCompat
@@ -19,13 +20,14 @@ abstract class AuthenticatedReceiver : BroadcastReceiver() {
         private const val CHANNEL_ID = "auth_errors"
         private const val CHANNEL_NAME = "Authentication Errors"
         private const val NOTIFICATION_ID = 1450
+        private const val PERMISSION_START_STOP_SERVER = "moe.shizuku.manager.permission.START_STOP_SERVER"
     }
 
     final override fun onReceive(context: Context, intent: Intent) {
         val authToken = intent.getStringExtra("auth")
         val expectedToken = ShizukuSettings.getAuthToken()
 
-        if (isPrivilegedCaller()) {
+        if (isPrivilegedCaller(context)) {
             onAuthenticated(context, intent)
         } else if (authToken.isNullOrEmpty()) {
             context.notify(
@@ -42,10 +44,12 @@ abstract class AuthenticatedReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun isPrivilegedCaller(): Boolean {
+    private fun isPrivilegedCaller(context: Context): Boolean {
         val callingUid = Binder.getCallingUid()
         return callingUid == Process.SHELL_UID ||
-                callingUid == Process.ROOT_UID
+                callingUid == Process.ROOT_UID ||
+                context.checkCallingPermission(PERMISSION_START_STOP_SERVER) ==
+                PackageManager.PERMISSION_GRANTED
     }
 
     private fun Context.notify(title: Int, message: Int) {


### PR DESCRIPTION

> **Note:** This work was done primarily by AI. A human did some testing, but then decided to move away from AutoJs6 to a compiled Kotlin APK. As a result, these PRs are mostly just FYI and not necessarily in shape for direct merging. I thought it would be more useful to share them rather than letting them sit there, in the hope they may be of some use.

ManualStartReceiver and ManualStopReceiver extend AuthenticatedReceiver and are exported for automation apps. When triggered from adb shell (uid=2000) or root (uid=0), the auth token check rejects the intent because no per-install auth token is provided.

Shell and root callers are inherently trusted on the device — bypass the auth token check when the calling UID is SHELL_UID or ROOT_UID.