### PR TITLE
Add headless start/stop receivers with ADB recovery and exponential backoff retry

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -242,6 +242,17 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".receiver.HeadlessStartStopReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL">
+            <intent-filter>
+                <action android:name="${applicationId}.HEADLESS_START" />
+                <action android:name="${applicationId}.HEADLESS_STOP" />
+            </intent-filter>
+        </receiver>
+
         <receiver android:name=".receiver.NotifAttemptReceiver" />
         <receiver android:name=".receiver.NotifCancelReceiver" />
         <receiver android:name=".receiver.NotifRestoreReceiver" />

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.service.WatchdogService
+import moe.shizuku.manager.utils.HeadlessLogger
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import rikka.core.util.BuildUtils.atLeast30
@@ -40,6 +41,7 @@ class ShizukuApplication : Application() {
 
     private fun init(context: Context) {
         ShizukuSettings.initialize(context)
+        HeadlessLogger.init(context)
         LocaleDelegate.defaultLocale = ShizukuSettings.getLocale()
         AppCompatDelegate.setDefaultNightMode(ShizukuSettings.getNightMode())
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -9,8 +9,11 @@ import java.io.EOFException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
@@ -19,9 +22,36 @@ import moe.shizuku.manager.adb.AdbKey
 import moe.shizuku.manager.adb.PreferenceAdbKeyStore
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.EnvironmentUtils
+import moe.shizuku.manager.utils.HeadlessLogger
 import moe.shizuku.manager.utils.ShizukuStateMachine
 
 object AdbStarter {
+    private val directScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    fun startDirect(context: Context, port: Int, maxRetries: Int = 5, baseRetryDelayMs: Long = 10000) {
+        directScope.launch {
+            var retryDelay = 0L
+            var lastError: Exception? = null
+            for (attempt in 1..maxRetries) {
+                try {
+                    if (attempt > 1) delay(retryDelay)
+                    HeadlessLogger.i("AdbStarter", "Attempt $attempt/$maxRetries on port $port")
+                    startAdb(context, port)
+                    HeadlessLogger.i("AdbStarter", "Server started successfully")
+                    return@launch
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    lastError = e
+                    if (attempt < maxRetries) {
+                        retryDelay = if (retryDelay == 0L) baseRetryDelayMs else retryDelay * 2
+                        HeadlessLogger.w("AdbStarter", "Attempt $attempt failed, retrying in ${retryDelay}ms: ${e.message}")
+                    }
+                }
+            }
+            HeadlessLogger.e("AdbStarter", "Failed after $maxRetries attempts", lastError)
+        }
+    }
+
     suspend fun startAdb(context: Context, port: Int, log: ((String) -> Unit)? = null) {
         suspend fun AdbClient.runCommand(cmd: String) {
             command(cmd) { log?.invoke(String(it)) }

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -24,11 +24,17 @@ import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.HeadlessLogger
 import moe.shizuku.manager.utils.ShizukuStateMachine
+import android.util.Log
+import moe.shizuku.manager.AppConstants
 
 object AdbStarter {
     private val directScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     fun startDirect(context: Context, port: Int, maxRetries: Int = 5, baseRetryDelayMs: Long = 10000) {
+        if (ShizukuStateMachine.get() == ShizukuStateMachine.State.STARTING) {
+            Log.w(AppConstants.TAG, "startDirect: already starting, ignoring duplicate request")
+            return
+        }
         directScope.launch {
             var retryDelay = 0L
             var lastError: Exception? = null
@@ -49,6 +55,12 @@ object AdbStarter {
                 }
             }
             HeadlessLogger.e("AdbStarter", "Failed after $maxRetries attempts", lastError)
+            // startAdb() sets STARTING on entry but never resets on total failure,
+            // wedging every future start attempt behind the "already starting"
+            // guard above until something else (e.g. force-stop) clears it.
+            // update() reconciles against the real binder state (STOPPED unless
+            // a retry happened to succeed underneath us).
+            ShizukuStateMachine.update()
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/receiver/HeadlessStartStopReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/HeadlessStartStopReceiver.kt
@@ -1,0 +1,71 @@
+package moe.shizuku.manager.receiver
+
+import android.Manifest.permission.WRITE_SECURE_SETTINGS
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
+import moe.shizuku.manager.BuildConfig
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.AdbStarter
+import moe.shizuku.manager.utils.HeadlessLogger
+import moe.shizuku.manager.utils.ShizukuStateMachine
+import rikka.shizuku.Shizuku
+
+class HeadlessStartStopReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_HEADLESS_START -> {
+                HeadlessLogger.i("Start", "Headless start requested (version ${BuildConfig.VERSION_NAME})")
+                val launchMode = ShizukuSettings.getLastLaunchMode()
+                if (launchMode == ShizukuSettings.LaunchMethod.ADB || launchMode == ShizukuSettings.LaunchMethod.UNKNOWN) {
+                    tryEnsureWirelessAdb(context)
+                    val port = ShizukuSettings.getTcpPort()
+                    HeadlessLogger.i("Start", "Starting via ADB on port $port")
+                    AdbStarter.startDirect(context, port)
+                    setResult(0, "STARTING", null)
+                } else {
+                    ShizukuReceiverStarter.start(context, forceStart = true)
+                    setResult(0, "STARTING", null)
+                }
+            }
+            ACTION_HEADLESS_STOP -> {
+                HeadlessLogger.i("Stop", "Headless stop requested")
+                if (!ShizukuStateMachine.isRunning()) {
+                    setResult(2, "NOT_RUNNING", null)
+                    return
+                }
+                ShizukuStateMachine.set(ShizukuStateMachine.State.STOPPING)
+                runCatching { Shizuku.exit() }
+                setResult(0, "STOPPING", null)
+            }
+        }
+    }
+
+    private fun tryEnsureWirelessAdb(context: Context) {
+        if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) {
+            HeadlessLogger.w("Start", "WRITE_SECURE_SETTINGS not granted")
+            return
+        }
+        try {
+            val cr = context.contentResolver
+            if (Settings.Global.getInt(cr, Settings.Global.ADB_ENABLED, 0) == 0) {
+                Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
+                HeadlessLogger.i("Start", "Enabled USB ADB")
+            }
+            if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 0) {
+                Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                HeadlessLogger.i("Start", "Enabled wireless ADB")
+            }
+        } catch (e: Exception) {
+            HeadlessLogger.e("Start", "Failed to enable wireless ADB", e)
+        }
+    }
+
+    companion object {
+        val ACTION_HEADLESS_START = "${BuildConfig.APPLICATION_ID}.HEADLESS_START"
+        val ACTION_HEADLESS_STOP = "${BuildConfig.APPLICATION_ID}.HEADLESS_STOP"
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -18,6 +18,7 @@ import moe.shizuku.manager.R
 import moe.shizuku.manager.AppConstants
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
+import moe.shizuku.manager.adb.AdbStarter
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.SettingsPage
@@ -40,11 +41,15 @@ object ShizukuReceiverStarter {
     fun start(context: Context, forceStart: Boolean = false) {
         if ((UserHandleCompat.myUserId() > 0 || ShizukuStateMachine.isRunning()) && !forceStart) return
 
-        if (ShizukuSettings.getLastLaunchMode() == LaunchMethod.ROOT) {
+        val launchMode = ShizukuSettings.getLastLaunchMode()
+        if (launchMode == LaunchMethod.ROOT) {
             rootStart(context)
         } else if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || EnvironmentUtils.isTelevision() || EnvironmentUtils.getAdbTcpPort() > 0)
-            && ShizukuSettings.getLastLaunchMode() == LaunchMethod.ADB) {
-                if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED) {
+            && (launchMode == LaunchMethod.ADB || launchMode == LaunchMethod.UNKNOWN)) {
+                val tcpPort = EnvironmentUtils.getAdbTcpPort()
+                if (tcpPort > 0) {
+                    AdbStarter.startDirect(context, tcpPort)
+                } else if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED) {
                     AdbStartWorker.enqueue(context)
                     updateNotification(context, WorkerState.AWAITING_WIFI)
                 } else {

--- a/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
@@ -1,0 +1,68 @@
+package moe.shizuku.manager.utils
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object HeadlessLogger {
+
+    private const val TAG = "ShizukuHeadless"
+    private const val LOG_FILE = "headless.log"
+    private const val MAX_SIZE = 256 * 1024
+
+    private var logDir: File? = null
+    private var logFile: File? = null
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+
+    enum class Level { INFO, WARN, ERROR }
+
+    fun init(context: Context) {
+        if (logDir != null) return
+        logDir = context.getExternalFilesDir(null) ?: context.filesDir
+        logDir?.mkdirs()
+        logFile = logDir?.let { File(it, LOG_FILE) }
+    }
+
+    fun i(component: String, message: String) = log(Level.INFO, component, message)
+    fun w(component: String, message: String) = log(Level.WARN, component, message)
+    fun e(component: String, message: String, throwable: Throwable? = null) {
+        val msg = if (throwable != null) {
+            val sw = StringWriter()
+            throwable.printStackTrace(PrintWriter(sw))
+            "$message\n${sw.toString()}"
+        } else message
+        log(Level.ERROR, component, msg)
+    }
+
+    @Synchronized
+    private fun log(level: Level, component: String, message: String) {
+        val ts = dateFormat.format(Date())
+        val line = "$ts ${level.name.padEnd(5)} $component: $message"
+
+        Log.println(level.toLogPriority(), TAG, "$component: $message")
+
+        val file = logFile ?: return
+        try {
+            if (file.length() > MAX_SIZE) {
+                file.renameTo(File(file.parent, LOG_FILE + ".1"))
+            }
+            FileWriter(file, true).use { it.appendLine(line) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Cannot write log file: ${e.message}")
+        }
+    }
+
+    fun getLogPath(): String? = logFile?.absolutePath
+
+    private fun Level.toLogPriority(): Int = when (this) {
+        Level.INFO -> Log.INFO
+        Level.WARN -> Log.WARN
+        Level.ERROR -> Log.ERROR
+    }
+}


### PR DESCRIPTION

> **Note:** This work was done primarily by AI. A human did some testing, but then decided to move away from AutoJs6 to a compiled Kotlin APK. As a result, these PRs are mostly just FYI and not necessarily in shape for direct merging. I thought it would be more useful to share them rather than letting them sit there, in the hope they may be of some use.

Introduce HeadlessStartStopReceiver — shell/system-only broadcasts protected by INTERACT_ACROSS_USERS_FULL for unattended fleet/automation.

**HEADLESS_START:** Enables wireless ADB if WRITE_SECURE_SETTINGS is held, then calls AdbStarter.startDirect() with exponential backoff retry (5 attempts, 10s base, up to ~5 min window). Accepts UNKNOWN launch mode so fresh installs work without opening the UI.

**HEADLESS_STOP:** Calls Shizuku.exit() if the server is running.

**AdbStarter.startDirect():** New fire-and-forget coroutine wrapper around startAdb() with exponential backoff. Handles slow WiFi/ADB readiness on reboot.

**ShizukuReceiverStarter.start()** now:
- Treats UNKNOWN launch mode same as ADB (works on fresh installs)
- Checks getAdbTcpPort() — if already on TCP, starts directly via startDirect()

Thanks for the project — these changes complete the headless API surface for automation and fleet use cases.