### PR TITLE
Add PROVISION_AUTH receiver for headless auth token setup

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -242,6 +242,16 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".receiver.ProvisionAuthReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL">
+            <intent-filter>
+                <action android:name="${applicationId}.PROVISION_AUTH" />
+            </intent-filter>
+        </receiver>
+
         <receiver android:name=".receiver.NotifAttemptReceiver" />
         <receiver android:name=".receiver.NotifCancelReceiver" />
         <receiver android:name=".receiver.NotifRestoreReceiver" />

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.service.WatchdogService
+import moe.shizuku.manager.utils.HeadlessLogger
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import rikka.core.util.BuildUtils.atLeast30
@@ -40,6 +41,7 @@ class ShizukuApplication : Application() {
 
     private fun init(context: Context) {
         ShizukuSettings.initialize(context)
+        HeadlessLogger.init(context)
         LocaleDelegate.defaultLocale = ShizukuSettings.getLocale()
         AppCompatDelegate.setDefaultNightMode(ShizukuSettings.getNightMode())
 

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
@@ -133,6 +133,10 @@ public class ShizukuSettings {
         return token;
     }
 
+    public static void setAuthToken(String token) {
+        getPreferences().edit().putString("auth_token", token).apply();
+    }
+
     public static boolean getStartOnBoot(Context context) {
         ComponentName bootCompleteReceiver = new ComponentName(context.getPackageName(), BootCompleteReceiver.class.getName());
         int state = context.getPackageManager().getComponentEnabledSetting(bootCompleteReceiver);

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ProvisionAuthReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ProvisionAuthReceiver.kt
@@ -1,0 +1,42 @@
+package moe.shizuku.manager.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Binder
+import android.os.Process
+import android.widget.Toast
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.utils.HeadlessLogger
+
+class ProvisionAuthReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != "${context.packageName}.PROVISION_AUTH") return
+
+        HeadlessLogger.i("ProvisionAuth", "Auth token provisioning requested")
+
+        val callingUid = Binder.getCallingUid()
+        if (callingUid != Process.SHELL_UID && callingUid != Process.ROOT_UID) {
+            HeadlessLogger.w("ProvisionAuth", "Caller not shell/root (uid=$callingUid), rejected")
+            Toast.makeText(context, R.string.notification_auth_invalid_title, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val token = intent.getStringExtra("auth_token")
+        if (token.isNullOrEmpty()) {
+            HeadlessLogger.w("ProvisionAuth", "Missing auth token")
+            Toast.makeText(context, R.string.notification_auth_missing_title, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        ShizukuSettings.setAuthToken(token)
+        HeadlessLogger.i("ProvisionAuth", "Auth token set")
+        Toast.makeText(
+            context,
+            context.getString(R.string.home_automation_regenerate_token),
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ProvisionAuthReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ProvisionAuthReceiver.kt
@@ -20,19 +20,27 @@ class ProvisionAuthReceiver : BroadcastReceiver() {
         val callingUid = Binder.getCallingUid()
         if (callingUid != Process.SHELL_UID && callingUid != Process.ROOT_UID) {
             HeadlessLogger.w("ProvisionAuth", "Caller not shell/root (uid=$callingUid), rejected")
-            Toast.makeText(context, R.string.notification_auth_invalid_title, Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                context,
+                R.string.notification_auth_invalid_title,
+                Toast.LENGTH_SHORT,
+            ).show()
             return
         }
 
         val token = intent.getStringExtra("auth_token")
         if (token.isNullOrEmpty()) {
             HeadlessLogger.w("ProvisionAuth", "Missing auth token")
-            Toast.makeText(context, R.string.notification_auth_missing_title, Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                context,
+                R.string.notification_auth_missing_title,
+                Toast.LENGTH_SHORT,
+            ).show()
             return
         }
 
         ShizukuSettings.setAuthToken(token)
-        HeadlessLogger.i("ProvisionAuth", "Auth token set")
+        HeadlessLogger.i("ProvisionAuth", "Auth token set (len=${token.length})")
         Toast.makeText(
             context,
             context.getString(R.string.home_automation_regenerate_token),

--- a/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
@@ -1,0 +1,68 @@
+package moe.shizuku.manager.utils
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object HeadlessLogger {
+
+    private const val TAG = "ShizukuHeadless"
+    private const val LOG_FILE = "headless.log"
+    private const val MAX_SIZE = 256 * 1024
+
+    private var logDir: File? = null
+    private var logFile: File? = null
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+
+    enum class Level { INFO, WARN, ERROR }
+
+    fun init(context: Context) {
+        if (logDir != null) return
+        logDir = context.getExternalFilesDir(null) ?: context.filesDir
+        logDir?.mkdirs()
+        logFile = logDir?.let { File(it, LOG_FILE) }
+    }
+
+    fun i(component: String, message: String) = log(Level.INFO, component, message)
+    fun w(component: String, message: String) = log(Level.WARN, component, message)
+    fun e(component: String, message: String, throwable: Throwable? = null) {
+        val msg = if (throwable != null) {
+            val sw = StringWriter()
+            throwable.printStackTrace(PrintWriter(sw))
+            "$message\n${sw.toString()}"
+        } else message
+        log(Level.ERROR, component, msg)
+    }
+
+    @Synchronized
+    private fun log(level: Level, component: String, message: String) {
+        val ts = dateFormat.format(Date())
+        val line = "$ts ${level.name.padEnd(5)} $component: $message"
+
+        Log.println(level.toLogPriority(), TAG, "$component: $message")
+
+        val file = logFile ?: return
+        try {
+            if (file.length() > MAX_SIZE) {
+                file.renameTo(File(file.parent, LOG_FILE + ".1"))
+            }
+            FileWriter(file, true).use { it.appendLine(line) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Cannot write log file: ${e.message}")
+        }
+    }
+
+    fun getLogPath(): String? = logFile?.absolutePath
+
+    private fun Level.toLogPriority(): Int = when (this) {
+        Level.INFO -> Log.INFO
+        Level.WARN -> Log.WARN
+        Level.ERROR -> Log.ERROR
+    }
+}


### PR DESCRIPTION

> **Note:** This work was done primarily by AI. A human did some testing, but then decided to move away from AutoJs6 to a compiled Kotlin APK. As a result, these PRs are mostly just FYI and not necessarily in shape for direct merging. I thought it would be more useful to share them rather than letting them sit there, in the hope they may be of some use.

The authenticated start/stop intents (START/STOP with auth extra) are documented in the app but there's no way to set a known token from ADB without opening the UI at Settings > View intents > Regenerate token.

ProvisionAuthReceiver fills this gap: send a broadcast from adb shell with an auth_token extra, and it persists the token via ShizukuSettings.setAuthToken().

Protected by INTERACT_ACROSS_USERS_FULL (shell/system only). Validates caller UID and non-empty token. Adds ShizukuSettings.setAuthToken(String) alongside the existing getAuthToken()/generateAuthToken().

Usage: adb shell am broadcast -a moe.shizuku.privileged.api.PROVISION_AUTH -e auth_token YOUR_TOKEN