### PR TITLE
Add boot retry with exponential backoff for transient boot conditions

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.service.WatchdogService
+import moe.shizuku.manager.utils.HeadlessLogger
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import rikka.core.util.BuildUtils.atLeast30
@@ -40,6 +41,7 @@ class ShizukuApplication : Application() {
 
     private fun init(context: Context) {
         ShizukuSettings.initialize(context)
+        HeadlessLogger.init(context)
         LocaleDelegate.defaultLocale = ShizukuSettings.getLocale()
         AppCompatDelegate.setDefaultNightMode(ShizukuSettings.getNightMode())
 

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -3,15 +3,41 @@ package moe.shizuku.manager.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.util.Log
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.service.WatchdogService
+import moe.shizuku.manager.utils.HeadlessLogger
+import java.util.concurrent.TimeUnit
 
 class BootCompleteReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
 
+        HeadlessLogger.i("Boot", "Boot completed, starting Shizuku")
         ShizukuReceiverStarter.start(context)
-        if(ShizukuSettings.getWatchdog()) WatchdogService.start(context)
+        if (ShizukuSettings.getWatchdog()) WatchdogService.start(context)
+
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.NOT_ROAMING)
+            .build()
+
+        val retry = OneTimeWorkRequestBuilder<BootRetryWorker>()
+            .setConstraints(constraints)
+            .setInitialDelay(10, TimeUnit.SECONDS)
+            .setBackoffCriteria(
+                androidx.work.BackoffPolicy.EXPONENTIAL,
+                10, TimeUnit.SECONDS
+            )
+            .addTag("boot_retry")
+            .build()
+
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork("boot_retry", ExistingWorkPolicy.REPLACE, retry)
+
+        HeadlessLogger.i("Boot", "Boot retry scheduled (10s initial, EXP backoff, max 5 attempts)")
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootRetryWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootRetryWorker.kt
@@ -1,0 +1,40 @@
+package moe.shizuku.manager.receiver
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.delay
+import moe.shizuku.manager.utils.HeadlessLogger
+import moe.shizuku.manager.utils.ShizukuStateMachine
+
+class BootRetryWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+
+    companion object {
+        private const val MAX_ATTEMPTS = 5
+        private const val VERIFY_DELAY_MS = 3000L
+    }
+
+    override suspend fun doWork(): Result {
+        if (runAttemptCount > MAX_ATTEMPTS) {
+            HeadlessLogger.w("BootRetry", "Max attempts ($MAX_ATTEMPTS) reached, giving up")
+            return Result.success()
+        }
+
+        if (ShizukuStateMachine.isRunning()) {
+            HeadlessLogger.i("BootRetry", "Shizuku already running (attempt $runAttemptCount)")
+            return Result.success()
+        }
+
+        HeadlessLogger.i("BootRetry", "Retrying Shizuku start (attempt $runAttemptCount/$MAX_ATTEMPTS)")
+        ShizukuReceiverStarter.start(applicationContext)
+
+        delay(VERIFY_DELAY_MS)
+        if (ShizukuStateMachine.isRunning()) {
+            HeadlessLogger.i("BootRetry", "Start succeeded (attempt $runAttemptCount)")
+            return Result.success()
+        }
+
+        HeadlessLogger.w("BootRetry", "Start not yet running, will retry (attempt $runAttemptCount)")
+        return Result.retry()
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/HeadlessLogger.kt
@@ -1,0 +1,68 @@
+package moe.shizuku.manager.utils
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object HeadlessLogger {
+
+    private const val TAG = "ShizukuHeadless"
+    private const val LOG_FILE = "headless.log"
+    private const val MAX_SIZE = 256 * 1024
+
+    private var logDir: File? = null
+    private var logFile: File? = null
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+
+    enum class Level { INFO, WARN, ERROR }
+
+    fun init(context: Context) {
+        if (logDir != null) return
+        logDir = context.getExternalFilesDir(null) ?: context.filesDir
+        logDir?.mkdirs()
+        logFile = logDir?.let { File(it, LOG_FILE) }
+    }
+
+    fun i(component: String, message: String) = log(Level.INFO, component, message)
+    fun w(component: String, message: String) = log(Level.WARN, component, message)
+    fun e(component: String, message: String, throwable: Throwable? = null) {
+        val msg = if (throwable != null) {
+            val sw = StringWriter()
+            throwable.printStackTrace(PrintWriter(sw))
+            "$message\n${sw.toString()}"
+        } else message
+        log(Level.ERROR, component, msg)
+    }
+
+    @Synchronized
+    private fun log(level: Level, component: String, message: String) {
+        val ts = dateFormat.format(Date())
+        val line = "$ts ${level.name.padEnd(5)} $component: $message"
+
+        Log.println(level.toLogPriority(), TAG, "$component: $message")
+
+        val file = logFile ?: return
+        try {
+            if (file.length() > MAX_SIZE) {
+                file.renameTo(File(file.parent, LOG_FILE + ".1"))
+            }
+            FileWriter(file, true).use { it.appendLine(line) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Cannot write log file: ${e.message}")
+        }
+    }
+
+    fun getLogPath(): String? = logFile?.absolutePath
+
+    private fun Level.toLogPriority(): Int = when (this) {
+        Level.INFO -> Log.INFO
+        Level.WARN -> Log.WARN
+        Level.ERROR -> Log.ERROR
+    }
+}


### PR DESCRIPTION

> **Note:** This work was done primarily by AI. A human did some testing, but then decided to move away from AutoJs6 to a compiled Kotlin APK. As a result, these PRs are mostly just FYI and not necessarily in shape for direct merging. I thought it would be more useful to share them rather than letting them sit there, in the hope they may be of some use.

On some devices, boot-time conditions (slow WiFi, ADB daemon not ready, OEM process freezing) prevent Shizuku from starting on the first ACTION_BOOT_COMPLETED. After that first attempt fails, there's no automatic recovery until the next reboot.

BootRetryWorker addresses this with a WorkManager-based retry:

- 10s initial delay after boot, then exponential backoff (10s base, ~2.5 min window)
- Max 5 attempts, each checking isRunning() first (short-circuits if already up)
- NOT_ROAMING network constraint prevents wasted attempts without connectivity
- Adds zero overhead on devices where boot start already succeeds

The worker is scheduled by BootCompleteReceiver and uses the same ShizukuReceiverStarter.start() path, so it benefits from all existing retry and recovery logic.